### PR TITLE
Add density-weighted conditioning for continuous observations

### DIFF
--- a/LANG.md
+++ b/LANG.md
@@ -410,9 +410,35 @@ two separate passes would mis-pair the lanes.
 > **Status: implemented** for `P`/`E`/`Var`/`Q`, including bound conditioned values and operations
 > on them. The estimate uses the *in-condition* sample size `m ≈ n·P(C)` for its standard error, so
 > a rarer condition self-reports a looser estimate. Conditioning is **rejection-based** (it keeps the
-> lanes where `C` happened): excellent when `P(C)` is not tiny, but it does **not** do importance
-> weighting or posterior/MCMC inference — observing a *continuous* measurement (`X == 4.7`) or a
-> rare/high-dimensional event is the separate inference track (see `GOAL.md`).
+> lanes where `C` happened) — except for **observations**, below. Rare/high-dimensional events and
+> MCMC-style posterior inference remain the separate inference track (see `GOAL.md`).
+
+**Observing a continuous draw: `| Y == v` (density weighting).** A continuous equality is
+measure-zero, so rejection alone could never satisfy it — but when the condition contains
+`Y == v` where `Y` **is a draw** (`Y ~ normal(mu, sigma)`, `~ exponential(rate)`, `~ unif(a, b)`
+— parameters may be constant or random), the query treats it as an *observation*: the draw is
+**clamped** to `v` and every lane is **weighted by the density** of `Y` at `v` (likelihood
+weighting — exact in expectation, self-normalized). This is Bayesian inference on continuous
+data:
+
+```
+mu ~ normal(0, 1)          # prior
+Y  ~ normal(mu, 1)         # one measurement
+E(mu | Y == 1)             # ≈ 0.5   — the conjugate posterior N(1/2, 1/2)
+Var(mu | Y == 1)           # ≈ 0.5
+E(mu | Y == 1 && mu > 0)   # observation + ordinary rejection conjunct, in one query
+```
+
+- The equality must observe **the drawn variable itself** (or, internally, its lowered
+  location–scale form). A *transform* (`X + Y == v`, `2*Y == v`, `count(flips) == 7`) is not
+  recognized and falls back to rejection — for a continuous transform that is the usual
+  "condition never occurred" error.
+- The `_int` families and discrete draws are *not* weighted: a discrete equality has positive
+  probability, so rejection already answers it.
+- Observing a value **outside the support** (`E(X | X == -1)` for an exponential) has zero
+  density everywhere — an error that says the condition carried no weight.
+- The standard error uses the **effective sample size** `(Σw)²/Σw²`, so unequal weights
+  self-report a looser estimate, exactly as a rare rejection condition does.
 
 ### Hierarchical distributions (a random parameter)
 
@@ -465,10 +491,13 @@ E(bias | count(flips) == 7)              # ≈ 0.667 — posterior mean after 7 
 
 ### Hazards and still-planned semantics
 
-- **Equality on a *continuous* RV is almost surely false.** `unif(a,b)` is continuous, so
-  `X == c` (and any `==` between continuous RVs) has probability ~0 — e.g. `unif(1,6) == 4`
-  is essentially never true. Use a discrete distribution (`unif_int`, `bernoulli`). A
-  **warning** on `==`/`!=` over a continuous RV is still TODO.
+- **Equality on a *continuous* RV is almost surely false** — *except after `|`*. `unif(a,b)` is
+  continuous, so `X == c` (and any `==` between continuous RVs) has probability ~0 — e.g.
+  `P(unif(1,6) == 4)` is essentially never true; use a discrete distribution (`unif_int`,
+  `bernoulli`) for equality *events*. But as a **condition** (`E(mu | Y == 2.5)`) a continuous
+  equality on a draw is a well-defined *observation*, answered by density weighting — see
+  "Conditioning". A **warning** on `==`/`!=` over a continuous RV outside a condition is still
+  TODO.
 - **Multiple queries do not yet share one sampling pass (TODO).** Each `P()` call currently
   samples its own cone with the default seed. The intended semantics is that all queries in
   a run share *one* batch of draws so `P(A)`, `P(B)`, `P(A && B)` are mutually consistent

--- a/crates/noise-core/src/builtins.rs
+++ b/crates/noise-core/src/builtins.rs
@@ -616,6 +616,144 @@ pub fn quantile_cond(
     Ok(Value::Num(empirical_quantile(&draws, q)))
 }
 
+// --- density-weighted conditional queries (see `crate::observe`): the condition contained an
+//     observation `Y == v` of a continuous draw, so lanes are *weighted* by the observed density
+//     instead of rejected. `quantity` is the (already clamp-rewritten) quantity — wrapped in the
+//     usual `select(residual, quantity, NaN)` when unrecognized conjuncts remain — and `weight`
+//     is the density root. Estimates are self-normalized; standard errors use the effective
+//     sample size `ess = (Σw)²/Σw²`.
+
+/// No lane carried weight: the observed value may lie outside its distribution's support (zero
+/// density), or the residual condition never held.
+fn cond_no_weight(n: usize, span: Span) -> NoiseError {
+    NoiseError::runtime(
+        format!(
+            "the condition after `|` carried no weight in {n} samples — the observed value may \
+             have zero density (outside its distribution's support), or the accompanying \
+             condition never occurred"
+        ),
+        span,
+    )
+}
+
+/// `P(event | … Y == v …)` — the weighted conditional probability.
+pub fn prob_cond_weighted(
+    graph: &RvGraph,
+    quantity: RvId,
+    weight: RvId,
+    tail: &[Value],
+    default_n: usize,
+    max_opts: u64,
+    span: Span,
+    check: bool,
+) -> Result<Value> {
+    if tail.len() > 1 {
+        return Err(NoiseError::runtime(
+            format!("P(event | cond) takes an optional sample count, got {} extra argument(s)", tail.len()),
+            span,
+        ));
+    }
+    let n = opt_count("P", tail.first(), default_n, span)?;
+    if check {
+        return Ok(Value::Est { val: 0.5, se: 0.0 });
+    }
+    let n = clamp_to_op_budget(n, graph, quantity, max_opts);
+    let n = clamp_to_op_budget(n, graph, weight, max_opts);
+    let m = sampler::weighted_cond_moments(graph, quantity, weight, n, P_DEFAULT_SEED);
+    if m.count == 0 {
+        return Err(cond_no_weight(n, span));
+    }
+    let p_hat = m.mean;
+    let se = (p_hat * (1.0 - p_hat) / m.ess).sqrt().max(0.5 / m.ess);
+    Ok(Value::Est { val: p_hat, se })
+}
+
+/// `E(x | … Y == v …)` / `Var(x | … Y == v …)` — weighted conditional moments.
+pub fn moment_cond_weighted(
+    name: &str,
+    graph: &RvGraph,
+    quantity: RvId,
+    weight: RvId,
+    tail: &[Value],
+    default_n: usize,
+    max_opts: u64,
+    span: Span,
+    check: bool,
+) -> Result<Value> {
+    if tail.len() > 1 {
+        return Err(NoiseError::runtime(
+            format!("{name}(x | cond) takes an optional sample count, got {} extra argument(s)", tail.len()),
+            span,
+        ));
+    }
+    let n = opt_count(name, tail.first(), default_n, span)?;
+    if check {
+        return Ok(Value::Est { val: 0.0, se: 0.0 });
+    }
+    let n = clamp_to_op_budget(n, graph, quantity, max_opts);
+    let n = clamp_to_op_budget(n, graph, weight, max_opts);
+    let m = sampler::weighted_cond_moments(graph, quantity, weight, n, P_DEFAULT_SEED);
+    if m.count == 0 {
+        return Err(cond_no_weight(n, span));
+    }
+    if name == "Var" {
+        Ok(Value::Est { val: m.variance, se: m.variance.abs() * (2.0 / m.ess).sqrt() })
+    } else {
+        Ok(Value::Est { val: m.mean, se: (m.variance / m.ess).sqrt() })
+    }
+}
+
+/// `Q(x | … Y == v …, q[, n])` — the weighted conditional quantile: sort the in-weight draws and
+/// take the smallest value whose cumulative weight reaches `q` of the total.
+pub fn quantile_cond_weighted(
+    graph: &RvGraph,
+    quantity: RvId,
+    weight: RvId,
+    tail: &[Value],
+    default_n: usize,
+    max_opts: u64,
+    span: Span,
+    check: bool,
+) -> Result<Value> {
+    if tail.is_empty() || tail.len() > 2 {
+        return Err(NoiseError::runtime(
+            format!(
+                "Q(x | cond, q[, n]) needs a quantile level q in [0,1] (and an optional sample count), got {} argument(s) after the condition",
+                tail.len()
+            ),
+            span,
+        ));
+    }
+    let q = as_num(&tail[0], span)?;
+    if !(0.0..=1.0).contains(&q) {
+        return Err(NoiseError::runtime(
+            format!("Q needs a quantile level q in [0, 1], got {q}"),
+            span,
+        ));
+    }
+    let n = opt_count("Q", tail.get(1), default_n, span)?;
+    if check {
+        return Ok(Value::Num(0.0));
+    }
+    let n = clamp_to_op_budget(n, graph, quantity, max_opts);
+    let n = clamp_to_op_budget(n, graph, weight, max_opts);
+    let mut draws = sampler::weighted_cond_draws(graph, quantity, weight, n, P_DEFAULT_SEED);
+    if draws.is_empty() {
+        return Err(cond_no_weight(n, span));
+    }
+    draws.sort_by(|a, b| a.0.total_cmp(&b.0));
+    let total: f64 = draws.iter().map(|&(_, w)| w).sum();
+    let target = q * total;
+    let mut cum = 0.0;
+    for &(x, w) in &draws {
+        cum += w;
+        if cum >= target {
+            return Ok(Value::Num(x));
+        }
+    }
+    Ok(Value::Num(draws.last().unwrap().0))
+}
+
 /// Linear-interpolated empirical quantile of a **sorted, non-empty** sample (the `type-7` rule,
 /// numpy's default): position `q*(len-1)`, blended between its floor/ceil order statistics.
 fn empirical_quantile(sorted: &[f64], q: f64) -> f64 {

--- a/crates/noise-core/src/eval.rs
+++ b/crates/noise-core/src/eval.rs
@@ -1082,10 +1082,40 @@ impl Engine {
                 span,
             ));
         }
-        let nan = self.graph.push(RvNode::ConstNum(f64::NAN), RvKind::Num);
-        let root = self.graph.push(RvNode::Select { cond: condition, a: quantity, b: nan }, RvKind::Num);
         let tail = &arg_vals[1..];
         let (default_n, max_opts, check) = (self.max_samples, self.max_opts, self.check_mode);
+        // Density-weighted observation (see `crate::observe`): when the condition contains a
+        // clampable equality on a continuous draw (`Y == 2.5`), rejection would reject every
+        // lane (measure zero). Instead clamp the draw, weight lanes by the observed density, and
+        // reject only on the residual (unrecognized) conjuncts. When nothing is clampable,
+        // `analyze` returns `None` and the rejection path below runs unchanged.
+        if let Some(plan) = crate::observe::analyze(&mut self.graph, condition) {
+            let quantity = plan.rewrite(&mut self.graph, quantity);
+            let weight = plan.rewrite(&mut self.graph, plan.weight);
+            let root = match plan.residual {
+                Some(residual) => {
+                    let residual = plan.rewrite(&mut self.graph, residual);
+                    let nan = self.graph.push(RvNode::ConstNum(f64::NAN), RvKind::Num);
+                    self.graph
+                        .push(RvNode::Select { cond: residual, a: quantity, b: nan }, RvKind::Num)
+                }
+                None => quantity,
+            };
+            return match qname {
+                "P" => builtins::prob_cond_weighted(
+                    &self.graph, root, weight, tail, default_n, max_opts, span, check,
+                ),
+                "E" | "Var" => builtins::moment_cond_weighted(
+                    qname, &self.graph, root, weight, tail, default_n, max_opts, span, check,
+                ),
+                "Q" => builtins::quantile_cond_weighted(
+                    &self.graph, root, weight, tail, default_n, max_opts, span, check,
+                ),
+                _ => unreachable!("query_cond dispatched with an unknown name"),
+            };
+        }
+        let nan = self.graph.push(RvNode::ConstNum(f64::NAN), RvKind::Num);
+        let root = self.graph.push(RvNode::Select { cond: condition, a: quantity, b: nan }, RvKind::Num);
         match qname {
             "P" => builtins::prob_cond(&self.graph, root, tail, default_n, max_opts, span, check),
             "E" | "Var" => {

--- a/crates/noise-core/src/lib.rs
+++ b/crates/noise-core/src/lib.rs
@@ -17,6 +17,7 @@ pub mod introspect;
 pub mod jit;
 pub mod kernel;
 pub mod lexer;
+pub mod observe;
 pub mod parser;
 pub mod reduce;
 pub mod rng;
@@ -316,6 +317,62 @@ mod tests {
         assert!((run_num("D ~ unif_int(1,6); E(D | D > 3)") - 5.0).abs() < 5e-3);
         assert!((run_num("D ~ unif_int(1,6); Var(D | D > 3)") - 2.0 / 3.0).abs() < 5e-3);
         assert!((run_num("D ~ unif_int(1,6); Q(D | D > 3, 0.5)") - 5.0).abs() < 1e-9);
+    }
+
+    // --- density-weighted observation: `| Y == v` on a continuous draw (see `observe.rs`) ---
+
+    #[test]
+    fn observing_a_continuous_draw_clamps_it() {
+        // A measure-zero condition that rejection can never satisfy: clamp + weight answers it.
+        assert_eq!(num("Z ~ normal(0,1); E(Z | Z == 1.5)"), 1.5);
+        assert_eq!(display_of("Z ~ normal(0,1); E(Z | Z == 1.5)"), "1.5");
+        assert!((num("X ~ exponential(2); E(X | X == 0.7)") - 0.7).abs() < 1e-9);
+        assert_eq!(num("U ~ unif(0,1); E(U | U == 0.3)"), 0.3);
+    }
+
+    #[test]
+    fn observing_a_hierarchical_normal_gives_the_conjugate_posterior() {
+        // mu ~ N(0,1), Y ~ N(mu,1), observe Y = 1: posterior is N(1/2, 1/2) (conjugate).
+        let m = "mu ~ normal(0,1); Y ~ normal(mu,1);";
+        assert!((num(&format!("{m} E(mu | Y == 1)")) - 0.5).abs() < 0.01);
+        assert!((num(&format!("{m} Var(mu | Y == 1)")) - 0.5).abs() < 0.01);
+        // P(mu > 0 | Y = 1) = Phi(0.5/sqrt(0.5)) ~= 0.760250.
+        assert!((num(&format!("{m} P(mu > 0 | Y == 1)")) - 0.760250).abs() < 0.01);
+        // Weighted conditional median of N(1/2, 1/2) is 1/2.
+        assert!((num(&format!("{m} Q(mu | Y == 1, 0.5)")) - 0.5).abs() < 0.01);
+        // A bound conditioned value takes the same weighted path.
+        assert!((num(&format!("{m} post = mu | Y == 1; E(post)")) - 0.5).abs() < 0.01);
+    }
+
+    #[test]
+    fn observation_mixes_with_rejection_conjuncts() {
+        // E(mu | Y == 1 && mu > 0): posterior N(1/2, 1/2) truncated to mu > 0, whose mean is
+        // 1/2 + sqrt(1/2)·phi(-1/sqrt(2))/Phi(1/sqrt(2)) ~= 0.78901.
+        let e = num("mu ~ normal(0,1); Y ~ normal(mu,1); E(mu | Y == 1 && mu > 0)");
+        assert!((e - 0.78901).abs() < 0.02, "truncated posterior mean = {e}");
+    }
+
+    #[test]
+    fn observing_a_hierarchical_uniform_weights_by_lane_density() {
+        // w ~ unif(0,1), Y ~ unif(0, w), observe Y = 0.2: posterior over w has density
+        // proportional to [w > 0.2]/w, so E(w | Y == 0.2) = 0.8/ln(5) ~= 0.49707.
+        let e = num("w ~ unif(0,1); Y ~ unif(0, w); E(w | Y == 0.2)");
+        assert!((e - 0.8 / 5.0f64.ln()).abs() < 0.01, "E(w | Y == 0.2) = {e}");
+    }
+
+    #[test]
+    fn observing_outside_the_support_is_a_zero_weight_error() {
+        // exponential draws are never negative: the observed density is exactly 0.
+        let err = run("X ~ exponential(1); E(X | X == -1)").unwrap_err();
+        assert!(err.to_string().contains("no weight"), "got: {err}");
+    }
+
+    #[test]
+    fn non_invertible_observation_still_takes_the_rejection_path() {
+        // X + Y == 1.5 is not a recognized clamp shape — it falls back to rejection, which
+        // (correctly, for now) reports the measure-zero condition as never occurring.
+        let err = run("X ~ normal(0,1); Y ~ normal(0,1); E(X | X + Y == 1.5)").unwrap_err();
+        assert!(err.to_string().contains("never occurred"), "got: {err}");
     }
 
     #[test]

--- a/crates/noise-core/src/observe.rs
+++ b/crates/noise-core/src/observe.rs
@@ -1,0 +1,410 @@
+//! Density-weighted conditioning ("observation" of continuous draws).
+//!
+//! Rejection conditioning keeps the lanes where the condition happened — which is *never* for a
+//! continuous equality: `E(mu | Y == 2.5)` has a measure-zero condition, so every lane is
+//! rejected and the query errors. But `Y == v` observing a draw with a known density has an
+//! exact importance-weighting answer (the `generate` operation of Gen [Cusumano-Towner et al.
+//! 2019] / likelihood weighting): **clamp the draw to `v` and weight each lane by the density of
+//! `Y` at `v`**. Self-normalized weighted averages over those lanes converge to the exact
+//! conditional — Bayesian inference on continuous data, with no surface-language change.
+//!
+//! [`analyze`] decomposes a condition into `&&`-conjuncts and recognizes the **clampable** ones:
+//! `pivot == v` (either side) where `v` is a constant and `pivot` is
+//! - a continuous source itself — `Src(Normal/Exp/Uniform)` (the all-const recipes), or
+//! - a hierarchical lowered shape (see `Engine::draw`): `mu + sigma·Z`, `E/rate`, `lo + width·U`
+//!   — where the parameters may be random. The base draw is solved for (`Z := (v−mu)/sigma`) and
+//!   the density (`normpdf((v−mu)/sigma)/|sigma|`, …) is built **as graph nodes**, so each Monte
+//!   Carlo lane weights by *its* parameter draw — exactly what a hierarchical posterior needs.
+//!
+//! Everything unrecognized stays a **residual** condition handled by ordinary rejection, so
+//! `E(mu | Y == 2.5 && mu > 0)` mixes weighting and rejection in one query. If *no* conjunct is
+//! clampable, `analyze` returns `None` and the query takes the unchanged rejection path.
+//!
+//! Non-goals (they fall back to rejection): non-invertible pivots (`X + Y == v`,
+//! `count(flips) == 7`), the `_int` families (a rounded equality has positive probability, so
+//! rejection already works), and discrete draws.
+
+use std::collections::{HashMap, HashSet};
+
+use crate::ast::{BinOp, UnOp};
+use crate::dist::{RvGraph, RvId, RvKind, RvNode, Source};
+
+/// `1/sqrt(2π)` — the standard normal density normalizer.
+const INV_SQRT_2PI: f64 = 0.398_942_280_401_432_7;
+
+/// One recognized observation: replace `source` (a base draw) with `replacement` everywhere, and
+/// multiply the lane weight by `weight` (the observed density, an `RvKind::Num` node).
+struct Clamp {
+    source: RvId,
+    replacement: RvId,
+    weight: RvId,
+}
+
+/// The compiled observation plan for one conditional query.
+pub struct Plan {
+    subst: HashMap<RvId, RvId>,
+    /// Product of the observed densities (an `RvKind::Num` node; per-lane when parameters are
+    /// random). NOT yet rewritten — pass it through [`Plan::rewrite`] like every other root.
+    pub weight: RvId,
+    /// The `&&`-fold of the unrecognized conjuncts (`None` when every conjunct was clamped).
+    /// NOT yet rewritten.
+    pub residual: Option<RvId>,
+}
+
+/// Try to turn `condition` into clamps + weights + a residual. `None` means no conjunct is
+/// clampable — take the rejection path unchanged.
+pub fn analyze(graph: &mut RvGraph, condition: RvId) -> Option<Plan> {
+    let mut conjuncts = Vec::new();
+    split_and(graph, condition, &mut conjuncts);
+
+    let mut clamps: Vec<Clamp> = Vec::new();
+    let mut clamped: HashSet<RvId> = HashSet::new();
+    let mut residual: Vec<RvId> = Vec::new();
+    for c in conjuncts {
+        match recognize(graph, c) {
+            // A second equality on an already-clamped draw stays a residual conjunct: it is
+            // evaluated under the first clamp, so a contradiction rejects every lane (a
+            // probability-0 conditional), which is the correct outcome.
+            Some(cl) if !clamped.contains(&cl.source) => {
+                clamped.insert(cl.source);
+                clamps.push(cl);
+            }
+            _ => residual.push(c),
+        }
+    }
+    if clamps.is_empty() {
+        return None;
+    }
+
+    let mut weight = clamps[0].weight;
+    for cl in &clamps[1..] {
+        weight = graph.push(RvNode::Binary(BinOp::Mul, weight, cl.weight), RvKind::Num);
+    }
+    let residual = residual.into_iter().reduce(|a, b| {
+        graph.push(RvNode::Binary(BinOp::And, a, b), RvKind::Bool)
+    });
+    let subst = clamps.into_iter().map(|c| (c.source, c.replacement)).collect();
+    Some(Plan { subst, weight, residual })
+}
+
+impl Plan {
+    /// Rebuild `root`'s cone with every clamped source replaced by its solved value. Replacement
+    /// cones are rewritten too (a clamp's parameters may themselves be clamped draws); this
+    /// terminates because a replacement only references nodes older than its source — the graph
+    /// is append-only, so substitution chains strictly descend.
+    pub fn rewrite(&self, graph: &mut RvGraph, root: RvId) -> RvId {
+        let mut memo: HashMap<RvId, RvId> = HashMap::new();
+        self.go(graph, root, &mut memo)
+    }
+
+    fn go(&self, graph: &mut RvGraph, id: RvId, memo: &mut HashMap<RvId, RvId>) -> RvId {
+        if let Some(&r) = memo.get(&id) {
+            return r;
+        }
+        if let Some(&target) = self.subst.get(&id) {
+            let r = self.go(graph, target, memo);
+            memo.insert(id, r);
+            return r;
+        }
+        let kind = graph.kind(id);
+        let node = graph.node(id).clone();
+        let new = match node {
+            // Leaves (unclamped sources and constants) stay in place.
+            RvNode::Src(_) | RvNode::ConstNum(_) | RvNode::ConstBool(_) => id,
+            RvNode::Unary(op, a) => {
+                let a2 = self.go(graph, a, memo);
+                if a2 == a { id } else { graph.push(RvNode::Unary(op, a2), kind) }
+            }
+            RvNode::Binary(op, a, b) => {
+                let (a2, b2) = (self.go(graph, a, memo), self.go(graph, b, memo));
+                if a2 == a && b2 == b { id } else { graph.push(RvNode::Binary(op, a2, b2), kind) }
+            }
+            RvNode::Select { cond, a, b } => {
+                let (c2, a2, b2) =
+                    (self.go(graph, cond, memo), self.go(graph, a, memo), self.go(graph, b, memo));
+                if c2 == cond && a2 == a && b2 == b {
+                    id
+                } else {
+                    graph.push(RvNode::Select { cond: c2, a: a2, b: b2 }, kind)
+                }
+            }
+            RvNode::Gather { elems, index } => {
+                let elems2: Box<[RvId]> = elems.iter().map(|&e| self.go(graph, e, memo)).collect();
+                let i2 = self.go(graph, index, memo);
+                if i2 == index && elems2.iter().zip(elems.iter()).all(|(a, b)| a == b) {
+                    id
+                } else {
+                    graph.push(RvNode::Gather { elems: elems2, index: i2 }, kind)
+                }
+            }
+        };
+        memo.insert(id, new);
+        new
+    }
+}
+
+/// Flatten nested `&&` into conjuncts (the only decomposition rejection distributes over).
+fn split_and(graph: &RvGraph, id: RvId, out: &mut Vec<RvId>) {
+    if let RvNode::Binary(BinOp::And, a, b) = *graph.node(id) {
+        split_and(graph, a, out);
+        split_and(graph, b, out);
+    } else {
+        out.push(id);
+    }
+}
+
+/// Recognize one conjunct as a clampable observation `pivot == v`.
+fn recognize(graph: &mut RvGraph, conjunct: RvId) -> Option<Clamp> {
+    let RvNode::Binary(BinOp::Eq, a, b) = *graph.node(conjunct) else { return None };
+    let (pivot, v) = match (graph.node(a), graph.node(b)) {
+        (_, RvNode::ConstNum(v)) => (a, *v),
+        (RvNode::ConstNum(v), _) => (b, *v),
+        _ => return None,
+    };
+    if !v.is_finite() {
+        return None;
+    }
+    clamp_pivot(graph, pivot, v)
+}
+
+// Small node-building helpers, so the density expressions below read like formulas.
+fn num(g: &mut RvGraph, v: f64) -> RvId {
+    g.push(RvNode::ConstNum(v), RvKind::Num)
+}
+fn bin(g: &mut RvGraph, op: BinOp, a: RvId, b: RvId) -> RvId {
+    let kind = match op {
+        BinOp::Lt | BinOp::Gt | BinOp::Le | BinOp::Ge | BinOp::Eq | BinOp::Ne | BinOp::And
+        | BinOp::Or => RvKind::Bool,
+        _ => RvKind::Num,
+    };
+    g.push(RvNode::Binary(op, a, b), kind)
+}
+fn un(g: &mut RvGraph, op: UnOp, a: RvId) -> RvId {
+    g.push(RvNode::Unary(op, a), RvKind::Num)
+}
+/// `|x|` as `x·sign(x)` (no Abs op in the VM).
+fn abs(g: &mut RvGraph, x: RvId) -> RvId {
+    let s = un(g, UnOp::Sign, x);
+    bin(g, BinOp::Mul, x, s)
+}
+/// `e^x` as `E^x` (`Pow` is the VM's exponential; there is no dedicated Exp op).
+fn exp(g: &mut RvGraph, x: RvId) -> RvId {
+    let e = num(g, std::f64::consts::E);
+    bin(g, BinOp::Pow, e, x)
+}
+
+/// Match `pivot` against the invertible draw shapes and build (replacement, density-weight).
+fn clamp_pivot(graph: &mut RvGraph, pivot: RvId, v: f64) -> Option<Clamp> {
+    match *graph.node(pivot) {
+        // --- direct sources (all-const recipes): the density is a plain constant ---
+        RvNode::Src(Source::Normal { mu, sigma }) => {
+            if !(sigma > 0.0) {
+                return None; // a point mass has no density; rejection handles it
+            }
+            let z = (v - mu) / sigma;
+            let w = INV_SQRT_2PI * (-0.5 * z * z).exp() / sigma;
+            let replacement = num(graph, v);
+            let weight = num(graph, w);
+            Some(Clamp { source: pivot, replacement, weight })
+        }
+        RvNode::Src(Source::Exp { rate }) => {
+            let w = if v >= 0.0 { rate * (-rate * v).exp() } else { 0.0 };
+            let replacement = num(graph, v);
+            let weight = num(graph, w);
+            Some(Clamp { source: pivot, replacement, weight })
+        }
+        RvNode::Src(Source::Uniform(u)) => {
+            if !(u.hi > u.lo) {
+                return None;
+            }
+            let w = if v >= u.lo && v < u.hi { 1.0 / (u.hi - u.lo) } else { 0.0 };
+            let replacement = num(graph, v);
+            let weight = num(graph, w);
+            Some(Clamp { source: pivot, replacement, weight })
+        }
+        // --- hierarchical lowered shapes: solve for the base draw; the density is per-lane ---
+        RvNode::Binary(BinOp::Add, x, y) => {
+            // normal: mu + sigma·Z, Z ~ N(0,1)  →  Z := (v−mu)/sigma, w = φ(Z)/|sigma|
+            if let Some((mu, sigma, z)) = match_scaled(graph, x, y, is_std_normal) {
+                let vv = num(graph, v);
+                let diff = bin(graph, BinOp::Sub, vv, mu);
+                let zval = bin(graph, BinOp::Div, diff, sigma);
+                let z2 = bin(graph, BinOp::Mul, zval, zval);
+                let half = num(graph, -0.5);
+                let arg = bin(graph, BinOp::Mul, half, z2);
+                let phi = exp(graph, arg);
+                let c = num(graph, INV_SQRT_2PI);
+                let numer = bin(graph, BinOp::Mul, c, phi);
+                let denom = abs(graph, sigma);
+                let weight = bin(graph, BinOp::Div, numer, denom);
+                return Some(Clamp { source: z, replacement: zval, weight });
+            }
+            // uniform: lo + width·U, U ~ unif(0,1)  →  U := (v−lo)/width,
+            // w = [0 ≤ U < 1] / |width|
+            if let Some((lo, width, u)) = match_scaled(graph, x, y, is_std_uniform) {
+                let vv = num(graph, v);
+                let diff = bin(graph, BinOp::Sub, vv, lo);
+                let uval = bin(graph, BinOp::Div, diff, width);
+                let zero = num(graph, 0.0);
+                let one = num(graph, 1.0);
+                let ge = bin(graph, BinOp::Ge, uval, zero);
+                let lt = bin(graph, BinOp::Lt, uval, one);
+                // 0/1 product = the in-support indicator, kept numeric for the division.
+                let ind = graph.push(RvNode::Binary(BinOp::Mul, ge, lt), RvKind::Num);
+                let denom = abs(graph, width);
+                let weight = bin(graph, BinOp::Div, ind, denom);
+                return Some(Clamp { source: u, replacement: uval, weight });
+            }
+            None
+        }
+        // exponential: E/rate, E ~ Exp(1)  →  E := v·rate, w = rate·e^{−rate·v}·[v ≥ 0]
+        RvNode::Binary(BinOp::Div, e, rate) => {
+            if !matches!(graph.node(e), RvNode::Src(Source::Exp { rate }) if *rate == 1.0) {
+                return None;
+            }
+            if v < 0.0 {
+                let replacement = num(graph, 0.0);
+                let weight = num(graph, 0.0);
+                return Some(Clamp { source: e, replacement, weight });
+            }
+            let vv = num(graph, v);
+            let replacement = bin(graph, BinOp::Mul, vv, rate);
+            let neg = un(graph, UnOp::Neg, replacement);
+            let ex = exp(graph, neg);
+            let weight = bin(graph, BinOp::Mul, rate, ex);
+            Some(Clamp { source: e, replacement, weight })
+        }
+        _ => None,
+    }
+}
+
+/// Match `param + scale·B` across operand orders: one of `(x, y)` is `Binary(Mul, s, b)` (either
+/// order) whose `b` satisfies `is_base`; the other is the location parameter. Returns
+/// `(param, scale, base)`.
+fn match_scaled(
+    graph: &RvGraph,
+    x: RvId,
+    y: RvId,
+    is_base: fn(&RvNode) -> bool,
+) -> Option<(RvId, RvId, RvId)> {
+    for (param, scaled) in [(x, y), (y, x)] {
+        if let RvNode::Binary(BinOp::Mul, p, q) = *graph.node(scaled) {
+            for (s, b) in [(p, q), (q, p)] {
+                if is_base(graph.node(b)) {
+                    return Some((param, s, b));
+                }
+            }
+        }
+    }
+    None
+}
+
+fn is_std_normal(n: &RvNode) -> bool {
+    matches!(n, RvNode::Src(Source::Normal { mu, sigma }) if *mu == 0.0 && *sigma == 1.0)
+}
+
+fn is_std_uniform(n: &RvNode) -> bool {
+    matches!(n, RvNode::Src(Source::Uniform(u)) if u.lo == 0.0 && u.hi == 1.0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dist::Uniform;
+
+    #[test]
+    fn direct_normal_equality_is_recognized() {
+        let mut g = RvGraph::default();
+        let y = g.push(RvNode::Src(Source::Normal { mu: 1.0, sigma: 2.0 }), RvKind::Num);
+        let c = num(&mut g, 2.0);
+        let eq = bin(&mut g, BinOp::Eq, y, c);
+        let plan = analyze(&mut g, eq).expect("normal == const must be clampable");
+        assert!(plan.residual.is_none());
+        // The weight is the constant normpdf(2; 1, 2).
+        let expected = INV_SQRT_2PI * (-0.125f64).exp() / 2.0;
+        match g.node(plan.weight) {
+            RvNode::ConstNum(w) => assert!((w - expected).abs() < 1e-15),
+            other => panic!("expected a constant weight, got {other:?}"),
+        }
+        // Rewriting the pivot yields the clamped constant.
+        let mut g2 = g;
+        let rewritten = plan.rewrite(&mut g2, y);
+        assert!(matches!(g2.node(rewritten), RvNode::ConstNum(v) if *v == 2.0));
+    }
+
+    #[test]
+    fn non_invertible_pivot_declines() {
+        // X + Y == 1.5 with two sources: not a recognized shape → rejection path.
+        let mut g = RvGraph::default();
+        let x = g.push(RvNode::Src(Source::Normal { mu: 0.0, sigma: 1.0 }), RvKind::Num);
+        let y = g.push(RvNode::Src(Source::Normal { mu: 0.0, sigma: 1.0 }), RvKind::Num);
+        let sum = bin(&mut g, BinOp::Add, x, y);
+        let c = num(&mut g, 1.5);
+        let eq = bin(&mut g, BinOp::Eq, sum, c);
+        assert!(analyze(&mut g, eq).is_none());
+    }
+
+    #[test]
+    fn mixed_condition_keeps_a_residual() {
+        // Y == 2.0 && Z > 0: the equality clamps, the inequality stays for rejection.
+        let mut g = RvGraph::default();
+        let y = g.push(RvNode::Src(Source::Normal { mu: 0.0, sigma: 1.0 }), RvKind::Num);
+        let z = g.push(RvNode::Src(Source::Normal { mu: 0.0, sigma: 1.0 }), RvKind::Num);
+        let c = num(&mut g, 2.0);
+        let eq = bin(&mut g, BinOp::Eq, y, c);
+        let zero = num(&mut g, 0.0);
+        let gt = bin(&mut g, BinOp::Gt, z, zero);
+        let both = bin(&mut g, BinOp::And, eq, gt);
+        let plan = analyze(&mut g, both).expect("the equality conjunct must clamp");
+        assert_eq!(plan.residual, Some(gt));
+    }
+
+    #[test]
+    fn hierarchical_normal_solves_for_the_base_draw() {
+        // mu_node + sigma·Z with Z ~ N(0,1): Z must be substituted, weight is per-lane.
+        let mut g = RvGraph::default();
+        let mu = g.push(RvNode::Src(Source::Normal { mu: 0.0, sigma: 1.0 }), RvKind::Num);
+        let z = g.push(RvNode::Src(Source::Normal { mu: 0.0, sigma: 1.0 }), RvKind::Num);
+        let sigma = num(&mut g, 1.0);
+        let scaled = bin(&mut g, BinOp::Mul, sigma, z);
+        let y = bin(&mut g, BinOp::Add, mu, scaled);
+        let c = num(&mut g, 1.0);
+        let eq = bin(&mut g, BinOp::Eq, y, c);
+        let plan = analyze(&mut g, eq).expect("lowered normal must clamp");
+        // The clamped source is Z (the base draw), not mu (the parameter).
+        assert!(plan.subst.contains_key(&z));
+        assert!(!plan.subst.contains_key(&mu));
+        // Rewriting Y itself yields mu + sigma·((1 − mu)/sigma) — no Z left in the cone.
+        let mut g2 = g;
+        let y2 = plan.rewrite(&mut g2, y);
+        let mut stack = vec![y2];
+        while let Some(id) = stack.pop() {
+            assert_ne!(id, z, "the base draw must be substituted away");
+            match g2.node(id) {
+                RvNode::Unary(_, a) => stack.push(*a),
+                RvNode::Binary(_, a, b) => stack.extend([*a, *b]),
+                RvNode::Select { cond, a, b } => stack.extend([*cond, *a, *b]),
+                RvNode::Gather { elems, index } => {
+                    stack.extend(elems.iter().copied());
+                    stack.push(*index);
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn contradictory_double_clamp_leaves_second_as_residual() {
+        let mut g = RvGraph::default();
+        let y = g.push(RvNode::Src(Source::Uniform(Uniform { lo: 0.0, hi: 1.0 })), RvKind::Num);
+        let c1 = num(&mut g, 0.3);
+        let c2 = num(&mut g, 0.7);
+        let eq1 = bin(&mut g, BinOp::Eq, y, c1);
+        let eq2 = bin(&mut g, BinOp::Eq, y, c2);
+        let both = bin(&mut g, BinOp::And, eq1, eq2);
+        let plan = analyze(&mut g, both).unwrap();
+        // One clamp, one residual (which will reject every lane — probability 0, correctly).
+        assert_eq!(plan.subst.len(), 1);
+        assert!(plan.residual.is_some());
+    }
+}

--- a/crates/noise-core/src/sampler.rs
+++ b/crates/noise-core/src/sampler.rs
@@ -83,6 +83,98 @@ pub fn cond_sample_n(graph: &RvGraph, root: RvId, n: usize, seed: u64) -> Vec<f6
     out
 }
 
+/// Self-normalized weighted moments — the forcing path behind a **density-weighted** conditional
+/// (`E(mu | Y == 2.5)`, see [`crate::observe`]). One joint pass over `(quantity, weight)`
+/// ([`compile_roots`], shared upstream draws); a NaN quantity lane (the residual-condition
+/// sentinel) or a non-finite/zero weight contributes nothing. Mean and variance are the
+/// weighted averages `Σwx/Σw` and `Σwx²/Σw − mean²`; `ess = (Σw)²/Σw²` is the effective sample
+/// size the standard error uses (with all-equal weights it equals the lane count, matching the
+/// unweighted formula). A single ordered RNG stream keeps the (quantity, weight) pairing exact.
+#[derive(Debug, Clone, Copy)]
+pub struct WeightedMoments {
+    pub mean: f64,
+    pub variance: f64,
+    /// Effective sample size `(Σw)²/Σw²`; `0` when no lane carried weight.
+    pub ess: f64,
+    /// Lanes with a positive, finite weight (and a non-NaN quantity).
+    pub count: u64,
+}
+
+pub fn weighted_cond_moments(
+    graph: &RvGraph,
+    quantity: RvId,
+    weight: RvId,
+    n: usize,
+    seed: u64,
+) -> WeightedMoments {
+    // Accumulate deviations from the first draw (`Σw·(x−x0)`), not raw `Σw·x`: a clamped
+    // (constant) quantity then comes out *exactly* — the deviation sum is exactly zero — and
+    // the cancellation error of `E[X²] − E[X]²` shrinks for everything else.
+    let (mut x0, mut w_sum, mut w_sq, mut wd, mut wd2, mut count) =
+        (None, 0.0f64, 0.0f64, 0.0f64, 0.0f64, 0u64);
+    for_each_weighted(graph, quantity, weight, n, seed, |x, w| {
+        let origin = *x0.get_or_insert(x);
+        let d = x - origin;
+        w_sum += w;
+        w_sq += w * w;
+        wd += w * d;
+        wd2 += w * d * d;
+        count += 1;
+    });
+    let (Some(x0), true) = (x0, w_sum > 0.0) else {
+        return WeightedMoments { mean: 0.0, variance: 0.0, ess: 0.0, count: 0 };
+    };
+    let dmean = wd / w_sum;
+    let variance = (wd2 / w_sum - dmean * dmean).max(0.0);
+    WeightedMoments { mean: x0 + dmean, variance, ess: w_sum * w_sum / w_sq, count }
+}
+
+/// The in-weight `(quantity, weight)` draws, for a weighted conditional quantile (unsorted).
+pub fn weighted_cond_draws(
+    graph: &RvGraph,
+    quantity: RvId,
+    weight: RvId,
+    n: usize,
+    seed: u64,
+) -> Vec<(f64, f64)> {
+    let mut out = Vec::new();
+    for_each_weighted(graph, quantity, weight, n, seed, |x, w| out.push((x, w)));
+    out
+}
+
+/// Drive one joint pass over `(quantity, weight)`, calling `sink` for every usable lane —
+/// non-NaN quantity, positive finite weight. Interpreter path (like [`sample_pairs`]): the
+/// conditioning budget is modest and the two-column read needs the raw register file.
+fn for_each_weighted(
+    graph: &RvGraph,
+    quantity: RvId,
+    weight: RvId,
+    n: usize,
+    seed: u64,
+    mut sink: impl FnMut(f64, f64),
+) {
+    if n == 0 {
+        return;
+    }
+    let (prog, regs) = compile_roots(graph, &[quantity, weight]);
+    let (rq, rw) = (regs[0] as usize, regs[1] as usize);
+    let mut buf: Vec<Box<[f64]>> =
+        (0..prog.n_regs).map(|_| vec![0.0f64; BATCH].into_boxed_slice()).collect();
+    let mut rng = Rng::seed_from_u64(seed);
+    let mut remaining = n;
+    while remaining > 0 {
+        run_batch(&prog, &mut buf, &mut rng);
+        let take = remaining.min(BATCH);
+        for k in 0..take {
+            let (x, w) = (buf[rq][k], buf[rw][k]);
+            if !x.is_nan() && w.is_finite() && w > 0.0 {
+                sink(x, w);
+            }
+        }
+        remaining -= take;
+    }
+}
+
 /// Joint draws of two roots — the forcing path behind `corr`/`scatter` (relationship
 /// introspection). `a` and `b` are sampled in **one** pass over a shared instruction stream
 /// ([`compile_roots`]), so each returned `(aᵢ, bᵢ)` is one lane's *paired* draw (shared upstream

--- a/crates/noise-core/src/value.rs
+++ b/crates/noise-core/src/value.rs
@@ -171,8 +171,9 @@ impl fmt::Display for Value {
             Value::Recipe(r) => write!(f, "{r}"),
             // No sampling on Display — keep it pure/cheap.
             Value::Dist(id) => write!(f, "<dist #{}>", id.0),
-            // Show only the digits the standard error justifies.
-            Value::Est { val, se } => write!(f, "{}", round_to_se(*val, *se)),
+            // Show only the digits the standard error justifies. An exact result (`se == 0`,
+            // e.g. from enumeration) prints like a plain number — dust-trimmed, not 17 digits.
+            Value::Est { val, se } => write!(f, "{}", format_num(round_to_se(*val, *se))),
             // `[a, b, c]` — comma-joined elements via their own Display.
             Value::Array(xs) => {
                 write!(f, "[")?;

--- a/examples/normal_posterior.noise
+++ b/examples/normal_posterior.noise
@@ -1,0 +1,22 @@
+# Observing a continuous measurement — Bayesian inference with `| Y == v`.
+#
+# A continuous equality has probability 0, so rejection could never satisfy it. When the
+# condition observes a draw directly, the engine clamps the draw and weights each lane by the
+# observed density (likelihood weighting) — the textbook conjugate-normal posterior, no
+# inference ceremony.
+#
+# Prior mu ~ N(0,1), measurement Y ~ N(mu,1), observe Y = 1:
+# posterior is N(1/2, 1/2)  ->  E = 0.5, Var = 0.5, P(mu > 0) = Phi(1/sqrt(2)) ~= 0.760.
+use rand;
+
+mu ~ normal(0, 1)          # prior belief about the quantity
+Y  ~ normal(mu, 1)         # one noisy measurement of it
+
+Print("prior mean          =", E(mu))
+Print("posterior mean      =", E(mu | Y == 1))        # ~ 0.5
+Print("posterior variance  =", Var(mu | Y == 1))      # ~ 0.5
+Print("P(mu > 0 | Y == 1)  =", P(mu > 0 | Y == 1))    # ~ 0.760
+Print("posterior median    =", Q(mu | Y == 1, 0.5))   # ~ 0.5
+
+# Observation composes with ordinary rejection conditions in one query:
+Print("E(mu | Y == 1, mu>0) =", E(mu | Y == 1 && mu > 0))  # ~ 0.789 (truncated posterior)


### PR DESCRIPTION
## What

`E(mu | Y == 2.5)` was impossible: a continuous equality is measure-zero, so rejection rejects every lane and the query errors ("condition never occurred"). This PR makes such conditions well-defined **observations**: when the condition contains `Y == v` where `Y` is a draw, the engine clamps the draw to `v` and weights each Monte Carlo lane by the density of `Y` at `v` — likelihood weighting (Gen's `generate` operation), exact in expectation, self-normalized. Bayesian inference on continuous data, with zero surface-language change:

```
mu ~ normal(0, 1)          # prior
Y  ~ normal(mu, 1)         # one noisy measurement
E(mu | Y == 1)             # ≈ 0.5  — the conjugate posterior N(1/2, 1/2)
Var(mu | Y == 1)           # ≈ 0.5
P(mu > 0 | Y == 1)         # ≈ 0.760
E(mu | Y == 1 && mu > 0)   # ≈ 0.789 — observation + rejection conjunct in one query
```

Hierarchical uniforms work too — `w ~ unif(0,1); Y ~ unif(0, w); E(w | Y == 0.2)` ≈ `0.8/ln 5` — because the density is built as **graph nodes**, so each lane weights by its own parameter draw.

## How

- **`observe.rs`**: splits the condition into `&&`-conjuncts and recognizes clampable equalities — direct sources (`Src(Normal/Exp/Uniform)`, constant density computed in Rust) and the hierarchical lowered shapes from `Engine::draw` (`mu + sigma·Z`, `E/rate`, `lo + width·U` — solve for the base draw, density per-lane). Substitution rebuilds the cone append-only (`Plan::rewrite`); replacement cones only reference older nodes, so chains strictly descend and terminate.
- Unrecognized conjuncts stay a **residual** handled by the existing `select(C, x, NaN)` rejection sentinel, so weighting and rejection compose in one query. A second equality on an already-clamped draw stays residual, which makes contradictory observations correctly reject everything.
- **Weighted `P`/`E`/`Var`/`Q`** (`sampler.rs`, `builtins.rs`): one joint `(quantity, weight)` interpreter pass (shared upstream draws, like `sample_pairs`), self-normalized; standard errors use the effective sample size `(Σw)²/Σw²` (which degenerates to the lane count for equal weights, matching the unweighted formulas). Mean-shifted accumulation makes clamped constants exact (`E(Z | Z == 1.5)` is exactly `1.5`).
- **When nothing is clampable, `analyze` returns `None` and the rejection path runs unchanged** — all 253 pre-existing tests pass without modification.

## Deliberately out of scope (falls back to rejection)

- Non-invertible pivots: `X + Y == v`, `2*Y == v`, `count(flips) == 7` — estimating densities of compound expressions is the GenSP/RAVI track.
- `_int` families and discrete draws — a discrete equality has positive probability, so rejection already answers it.
- Introspection (`hist(mu | Y == 1)`) still uses rejection and will report the measure-zero condition as never occurring.

## Errors

- Observing outside the support (`E(X | X == -1)` for an exponential): "carried no weight" — distinct from the rejection error, since more samples can't fix zero density.

## Tests

- 5 unit tests in `observe.rs` (recognition, decline, residual mixing, hierarchical solve, contradictory double-clamp).
- 6 end-to-end suites in `lib.rs`: direct clamps exact; conjugate-normal posterior (mean/var/tail/median/bound-value ≈ analytic); truncated posterior via mixed conjuncts; hierarchical-uniform posterior ≈ `0.8/ln 5`; zero-density error; non-invertible fallback.
- New example `examples/normal_posterior.noise`; LANG.md documents the observation semantics and updates the continuous-`==` hazard.
- All 264 noise-core tests and all examples pass.

## Note

Independent of #3 (exact enumeration) — both branch from master and meet only at the conditional-query dispatch, plus one identical one-line display fix in `value.rs`; whichever merges second rebases trivially.