### PR TITLE
Playground: Code/Split/Render view switcher

### DIFF
--- a/packages/www/src/components/Playground.astro
+++ b/packages/www/src/components/Playground.astro
@@ -8,29 +8,6 @@
 ---
 
 <section id="playground" class="playground">
-  <div class="pg-viewbar">
-    <div class="pg-viewtabs" id="pg-viewtabs" role="group" aria-label="Choose editor and render layout">
-      <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
-        <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
-          <path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path>
-        </svg>
-        <span>Code</span>
-      </button>
-      <button class="pg-viewtab pg-viewtab-split" data-view="split" type="button" aria-pressed="false" title="Editor and render side by side">
-        <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
-          <rect x="4" y="5" width="7" height="14" rx="1"></rect><rect x="13" y="5" width="7" height="14" rx="1"></rect>
-        </svg>
-        <span>Split</span>
-      </button>
-      <button class="pg-viewtab" data-view="render" type="button" aria-pressed="false" title="Render only">
-        <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
-          <rect x="4" y="5" width="16" height="14" rx="1"></rect><path d="M4 9h16"></path>
-        </svg>
-        <span>Render</span>
-      </button>
-    </div>
-  </div>
-
   <div class="pg-split" id="pg-split" data-view="split">
     <div class="pg-editor-wrap glass">
       <div class="pg-toolbar">
@@ -41,6 +18,20 @@
           <span class="btn-icon">▶</span> Run
           <span class="kbd">⌘↵</span>
         </button>
+        <div class="pg-viewtabs pg-viewtabs-edit" role="group" aria-label="Choose editor and render layout">
+          <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
+            <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg>
+            <span>Code</span>
+          </button>
+          <button class="pg-viewtab pg-viewtab-split" data-view="split" type="button" aria-pressed="false" title="Editor and render side by side">
+            <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="7" height="14" rx="1"></rect><rect x="13" y="5" width="7" height="14" rx="1"></rect></svg>
+            <span>Split</span>
+          </button>
+          <button class="pg-viewtab" data-view="render" type="button" aria-pressed="false" title="Render only">
+            <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="16" height="14" rx="1"></rect><path d="M4 9h16"></path></svg>
+            <span>Render</span>
+          </button>
+        </div>
       </div>
       <div id="editor" class="pg-editor"></div>
     </div>
@@ -92,6 +83,20 @@
               </button>
             </div>
           </div>
+          <div class="pg-viewtabs pg-viewtabs-out" role="group" aria-label="Choose editor and render layout">
+            <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg>
+              <span>Code</span>
+            </button>
+            <button class="pg-viewtab pg-viewtab-split" data-view="split" type="button" aria-pressed="false" title="Editor and render side by side">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="7" height="14" rx="1"></rect><rect x="13" y="5" width="7" height="14" rx="1"></rect></svg>
+              <span>Split</span>
+            </button>
+            <button class="pg-viewtab" data-view="render" type="button" aria-pressed="false" title="Render only">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="16" height="14" rx="1"></rect><path d="M4 9h16"></path></svg>
+              <span>Render</span>
+            </button>
+          </div>
         </div>
       </div>
       <div id="pg-output" class="pg-output is-preview"><span class="muted">Press Run to evaluate.</span></div>
@@ -102,20 +107,27 @@
 <style>
   .playground { max-width: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1rem; }
 
-  /* Segmented control to switch the layout between Code-only, Split, and Render-only. Persisted so a
-     reader keeps whichever focus they picked; the Split segment is hidden on narrow screens where a
-     two-pane split can't breathe (there the view falls back to a single pane). */
-  .pg-viewbar { display: flex; justify-content: center; }
+  /* Segmented control to switch the layout between Code-only, Split, and Render-only. It lives in the
+     header rows (never its own bar, to save vertical space): a copy in the editor toolbar carries it
+     in Code view, and a copy in the Render header carries it in Split/Render — exactly one shows per
+     view, so there's always one control, pinned to the far right. Both drive the same persisted state.
+     The Split segment is hidden on narrow screens where a two-pane split can't breathe. */
   .pg-viewtabs {
     display: inline-flex; align-items: stretch; gap: 2px;
     padding: 2px; border: 1px solid var(--rule); border-radius: 9px; background: var(--paper-2);
   }
+  /* The editor-toolbar copy sits at the toolbar's right edge and only shows when the editor is the
+     whole view (Code); in Split the Render-header copy is the visible one. */
+  .pg-viewtabs-edit { margin-left: auto; display: none; }
+  .pg-split[data-view='code'] .pg-viewtabs-edit { display: inline-flex; }
+  .pg-split[data-view='split'] .pg-viewtabs-edit,
+  .pg-split[data-view='render'] .pg-viewtabs-edit { display: none; }
   .pg-viewtab {
-    font: inherit; font-size: 0.74rem; font-variant: small-caps; letter-spacing: 0.05em;
+    font: inherit; font-size: 0.72rem; font-variant: small-caps; letter-spacing: 0.05em;
     color: var(--ink-dim); background: transparent;
     border: 1px solid transparent; border-radius: 7px;
-    padding: 0.28rem 0.85rem; cursor: pointer;
-    display: inline-flex; align-items: center; gap: 0.42rem;
+    padding: 0.2rem 0.62rem; cursor: pointer;
+    display: inline-flex; align-items: center; gap: 0.36rem;
     transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
   }
   .pg-viewtab svg { stroke: currentColor; stroke-width: 1.9; fill: none; stroke-linecap: round; stroke-linejoin: round; }
@@ -565,6 +577,23 @@
   // so the header shows before the first run too. After a run, `renderPreview` uses `res.meta`.
   let currentHeaderMeta: { title?: string; abstract?: string; tags?: string[] } | null = null;
 
+  // The layout view (Code / Split / Render). Declared up here (before `shareHash`/`loadFromHash`
+  // run) so the fragment can carry it and reloads restore it. Source of truth on load: the `v=`
+  // fragment param, then the persisted preference, then Split. The controls are wired further down.
+  const VIEW_KEY = 'noise-pg-view';
+  type ViewMode = 'code' | 'split' | 'render';
+  const isViewMode = (v: unknown): v is ViewMode => v === 'code' || v === 'split' || v === 'render';
+  const readView = (): ViewMode => {
+    const fromHash = parseHash(location.hash).view;
+    if (isViewMode(fromHash)) return fromHash;
+    try {
+      const v = localStorage.getItem(VIEW_KEY);
+      if (isViewMode(v)) return v;
+    } catch {}
+    return 'split';
+  };
+  let viewPref: ViewMode = readView();
+
   const editor = monaco.editor.create($('editor'), {
     value: byId.get(defaultExampleId)?.code ?? examples[0]?.code ?? '',
     language: LANGUAGE_ID,
@@ -624,13 +653,16 @@
   }
 
   // The shareable fragment: #x=id (unmodified example) or #c=snapshot, plus #i=name:value for any
-  // tuned inputs — so a tuned example is shareable exactly as tuned.
+  // tuned inputs and #v=view for a non-default layout — so a tuned example in a chosen view is
+  // shareable exactly as seen. The default Split view is left off to keep the common link clean.
   function shareHash(): string {
     const code = editor.getValue();
     const ex = currentId ? byId.get(currentId) : undefined;
-    const base = ex && ex.code.trim() === code.trim() ? `#x=${currentId}` : `#c=${encodeCode(code)}`;
+    let hash = ex && ex.code.trim() === code.trim() ? `#x=${currentId}` : `#c=${encodeCode(code)}`;
     const nd = nonDefaultInputs();
-    return Object.keys(nd).length ? `${base}&i=${encodeInputs(nd)}` : base;
+    if (Object.keys(nd).length) hash += `&i=${encodeInputs(nd)}`;
+    if (viewPref !== 'split') hash += `&v=${viewPref}`;
+    return hash;
   }
 
   /** Read the program's frontmatter and refresh the pre-run paper header (title/abstract/tags), so
@@ -714,7 +746,7 @@
     select.value = id;
     inputValues = { ...(inputs ?? {}) };
     if (loadCode) editor.setValue(ex.code);
-    if (updateHash) setHash(`#x=${id}`);
+    if (updateHash) setHash(viewPref !== 'split' ? `#x=${id}&v=${viewPref}` : `#x=${id}`);
     clearOutput();
     // Refresh the header, then auto-run — inputs (and their controls) come from the run itself.
     void refreshHeader().then(() => { if (autoRun) void execute(); });
@@ -733,6 +765,8 @@
 
   function loadFromHash({ updateHash = false } = {}) {
     const parsed = parseHash(location.hash);
+    // A `v=` in the link opens (or re-opens, on an external hash change) in that layout.
+    if (isViewMode(parsed.view)) viewPref = parsed.view;
     if (parsed.exampleId && byId.has(parsed.exampleId)) {
       selectExample(parsed.exampleId, { loadCode: true, updateHash, inputs: parsed.inputs, autoRun: true });
     } else if (parsed.code !== undefined) {
@@ -1223,23 +1257,13 @@
   });
 
   // --- layout view switcher (Code / Split / Render) ---
-  // The reader's choice is persisted so they keep the same focus next visit and on shared links.
-  // On narrow screens a side-by-side split doesn't fit, so the Split option falls back to a single
-  // pane there while the stored preference is left intact for when they're back on a wide screen.
-  const VIEW_KEY = 'noise-pg-view';
-  type ViewMode = 'code' | 'split' | 'render';
-  const isViewMode = (v: unknown): v is ViewMode => v === 'code' || v === 'split' || v === 'render';
+  // `viewPref` / `readView` are declared up top so the fragment carries the view and reloads restore
+  // it. The choice is also persisted so it survives a link with no `v=`. On narrow screens a
+  // side-by-side split doesn't fit, so `split` resolves to a single pane there while the stored
+  // preference is left intact for when the reader is back on a wide screen. There are two copies of
+  // the control (one per header row); both are wired here and only one shows per view.
   const narrow = window.matchMedia('(max-width: 880px)');
-  const viewTabs = Array.from(document.querySelectorAll<HTMLButtonElement>('#pg-viewtabs .pg-viewtab'));
-
-  const readView = (): ViewMode => {
-    try {
-      const v = localStorage.getItem(VIEW_KEY);
-      if (isViewMode(v)) return v;
-    } catch {}
-    return 'split';
-  };
-  let viewPref: ViewMode = readView();
+  const viewTabs = Array.from(document.querySelectorAll<HTMLButtonElement>('.pg-viewtab'));
 
   // What actually renders: `split` isn't offered on narrow screens, so it resolves to `code` there.
   const effectiveView = (): ViewMode => (narrow.matches && viewPref === 'split' ? 'code' : viewPref);
@@ -1256,6 +1280,7 @@
   function setView(v: ViewMode) {
     viewPref = v;
     try { localStorage.setItem(VIEW_KEY, v); } catch {}
+    setHash(shareHash());
     applyView();
   }
 
@@ -1372,6 +1397,8 @@
   });
 
   window.addEventListener('hashchange', () => {
-    if (!suppressHash) loadFromHash();
+    if (suppressHash) return;
+    loadFromHash();
+    applyView(); // an external hash change may carry a different `v=`
   });
 </script>

--- a/packages/www/src/components/Playground.astro
+++ b/packages/www/src/components/Playground.astro
@@ -11,13 +11,6 @@
   <div class="pg-split" id="pg-split" data-view="split">
     <div class="pg-editor-wrap glass">
       <div class="pg-toolbar">
-        <label class="pg-select-wrap">
-          <select id="pg-select" class="pg-select" aria-label="Choose an example"></select>
-        </label>
-        <button id="pg-run" class="btn btn-run" type="button">
-          <span class="btn-icon">▶</span> Run
-          <span class="kbd">⌘↵</span>
-        </button>
         <div class="pg-viewtabs pg-viewtabs-edit" role="group" aria-label="Choose editor and render layout">
           <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
             <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg>
@@ -32,6 +25,13 @@
             <span>Render</span>
           </button>
         </div>
+        <label class="pg-select-wrap">
+          <select id="pg-select" class="pg-select" aria-label="Choose an example"></select>
+        </label>
+        <button id="pg-run" class="btn btn-run" type="button">
+          <span class="btn-icon">▶</span> Run
+          <span class="kbd">⌘↵</span>
+        </button>
       </div>
       <div id="editor" class="pg-editor"></div>
     </div>
@@ -47,7 +47,23 @@
 
     <div class="pg-output-wrap glass">
       <div class="pg-output-head">
-        <span class="pg-output-title"><span class="dot"></span> Render</span>
+        <div class="pg-head-left">
+          <div class="pg-viewtabs pg-viewtabs-out" role="group" aria-label="Choose editor and render layout">
+            <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg>
+              <span>Code</span>
+            </button>
+            <button class="pg-viewtab pg-viewtab-split" data-view="split" type="button" aria-pressed="false" title="Editor and render side by side">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="7" height="14" rx="1"></rect><rect x="13" y="5" width="7" height="14" rx="1"></rect></svg>
+              <span>Split</span>
+            </button>
+            <button class="pg-viewtab" data-view="render" type="button" aria-pressed="false" title="Render only">
+              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="16" height="14" rx="1"></rect><path d="M4 9h16"></path></svg>
+              <span>Render</span>
+            </button>
+          </div>
+          <span class="pg-output-title"><span class="dot"></span> Render</span>
+        </div>
         <div class="pg-head-right">
           <div id="pg-metrics" class="pg-metrics" hidden></div>
           <div class="pg-share" id="pg-share">
@@ -83,20 +99,6 @@
               </button>
             </div>
           </div>
-          <div class="pg-viewtabs pg-viewtabs-out" role="group" aria-label="Choose editor and render layout">
-            <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
-              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path></svg>
-              <span>Code</span>
-            </button>
-            <button class="pg-viewtab pg-viewtab-split" data-view="split" type="button" aria-pressed="false" title="Editor and render side by side">
-              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="7" height="14" rx="1"></rect><rect x="13" y="5" width="7" height="14" rx="1"></rect></svg>
-              <span>Split</span>
-            </button>
-            <button class="pg-viewtab" data-view="render" type="button" aria-pressed="false" title="Render only">
-              <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true"><rect x="4" y="5" width="16" height="14" rx="1"></rect><path d="M4 9h16"></path></svg>
-              <span>Render</span>
-            </button>
-          </div>
         </div>
       </div>
       <div id="pg-output" class="pg-output is-preview"><span class="muted">Press Run to evaluate.</span></div>
@@ -116,12 +118,14 @@
     display: inline-flex; align-items: stretch; gap: 2px;
     padding: 2px; border: 1px solid var(--rule); border-radius: 9px; background: var(--paper-2);
   }
-  /* The editor-toolbar copy sits at the toolbar's right edge and only shows when the editor is the
+  /* The editor-toolbar copy sits at the toolbar's left edge and only shows when the editor is the
      whole view (Code); in Split the Render-header copy is the visible one. */
-  .pg-viewtabs-edit { margin-left: auto; display: none; }
+  .pg-viewtabs-edit { display: none; }
   .pg-split[data-view='code'] .pg-viewtabs-edit { display: inline-flex; }
   .pg-split[data-view='split'] .pg-viewtabs-edit,
   .pg-split[data-view='render'] .pg-viewtabs-edit { display: none; }
+  /* Left cluster of the Render header: the view toggle + the "Render" label. */
+  .pg-head-left { display: inline-flex; align-items: center; gap: 0.6rem; min-width: 0; }
   .pg-viewtab {
     font: inherit; font-size: 0.72rem; font-variant: small-caps; letter-spacing: 0.05em;
     color: var(--ink-dim); background: transparent;

--- a/packages/www/src/components/Playground.astro
+++ b/packages/www/src/components/Playground.astro
@@ -8,7 +8,30 @@
 ---
 
 <section id="playground" class="playground">
-  <div class="pg-split" id="pg-split">
+  <div class="pg-viewbar">
+    <div class="pg-viewtabs" id="pg-viewtabs" role="group" aria-label="Choose editor and render layout">
+      <button class="pg-viewtab" data-view="code" type="button" aria-pressed="false" title="Editor only">
+        <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
+          <path d="M9 8l-4 4 4 4"></path><path d="M15 8l4 4-4 4"></path>
+        </svg>
+        <span>Code</span>
+      </button>
+      <button class="pg-viewtab pg-viewtab-split" data-view="split" type="button" aria-pressed="false" title="Editor and render side by side">
+        <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
+          <rect x="4" y="5" width="7" height="14" rx="1"></rect><rect x="13" y="5" width="7" height="14" rx="1"></rect>
+        </svg>
+        <span>Split</span>
+      </button>
+      <button class="pg-viewtab" data-view="render" type="button" aria-pressed="false" title="Render only">
+        <svg viewBox="0 0 24 24" width="13" height="13" aria-hidden="true">
+          <rect x="4" y="5" width="16" height="14" rx="1"></rect><path d="M4 9h16"></path>
+        </svg>
+        <span>Render</span>
+      </button>
+    </div>
+  </div>
+
+  <div class="pg-split" id="pg-split" data-view="split">
     <div class="pg-editor-wrap glass">
       <div class="pg-toolbar">
         <label class="pg-select-wrap">
@@ -79,6 +102,30 @@
 <style>
   .playground { max-width: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 1rem; }
 
+  /* Segmented control to switch the layout between Code-only, Split, and Render-only. Persisted so a
+     reader keeps whichever focus they picked; the Split segment is hidden on narrow screens where a
+     two-pane split can't breathe (there the view falls back to a single pane). */
+  .pg-viewbar { display: flex; justify-content: center; }
+  .pg-viewtabs {
+    display: inline-flex; align-items: stretch; gap: 2px;
+    padding: 2px; border: 1px solid var(--rule); border-radius: 9px; background: var(--paper-2);
+  }
+  .pg-viewtab {
+    font: inherit; font-size: 0.74rem; font-variant: small-caps; letter-spacing: 0.05em;
+    color: var(--ink-dim); background: transparent;
+    border: 1px solid transparent; border-radius: 7px;
+    padding: 0.28rem 0.85rem; cursor: pointer;
+    display: inline-flex; align-items: center; gap: 0.42rem;
+    transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
+  }
+  .pg-viewtab svg { stroke: currentColor; stroke-width: 1.9; fill: none; stroke-linecap: round; stroke-linejoin: round; }
+  .pg-viewtab:hover { color: var(--ink); }
+  .pg-viewtab[aria-pressed='true'] {
+    color: var(--ink); background: var(--paper); border-color: var(--rule);
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+  }
+  .pg-viewtab:focus-visible { outline: 2px solid var(--link); outline-offset: 1px; }
+
   /* A resizable two-pane split. `--pg-left` is the editor's width fraction, dragged by the handle. */
   .pg-split {
     display: grid;
@@ -86,9 +133,18 @@
     align-items: stretch;
     min-height: clamp(460px, calc(100vh - 13rem), 940px);
   }
+  /* Single-pane views: collapse to one column and hide the resizer + the pane being focused away. */
+  .pg-split[data-view='code'],
+  .pg-split[data-view='render'] { grid-template-columns: 1fr; }
+  .pg-split[data-view='code'] .pg-resizer,
+  .pg-split[data-view='code'] .pg-output-wrap,
+  .pg-split[data-view='render'] .pg-resizer,
+  .pg-split[data-view='render'] .pg-editor-wrap { display: none; }
+
   @media (max-width: 880px) {
     .pg-split { grid-template-columns: 1fr; min-height: 0; gap: 1rem; }
     .pg-resizer { display: none; }
+    .pg-viewtab-split { display: none; }
   }
 
   .pg-resizer {
@@ -1157,6 +1213,53 @@
     if (e.key === 'ArrowLeft') setLeft(cur - 3);
     else if (e.key === 'ArrowRight') setLeft(cur + 3);
   });
+
+  // --- layout view switcher (Code / Split / Render) ---
+  // The reader's choice is persisted so they keep the same focus next visit and on shared links.
+  // On narrow screens a side-by-side split doesn't fit, so the Split option falls back to a single
+  // pane there while the stored preference is left intact for when they're back on a wide screen.
+  const VIEW_KEY = 'noise-pg-view';
+  type ViewMode = 'code' | 'split' | 'render';
+  const isViewMode = (v: unknown): v is ViewMode => v === 'code' || v === 'split' || v === 'render';
+  const narrow = window.matchMedia('(max-width: 880px)');
+  const viewTabs = Array.from(document.querySelectorAll<HTMLButtonElement>('#pg-viewtabs .pg-viewtab'));
+
+  const readView = (): ViewMode => {
+    try {
+      const v = localStorage.getItem(VIEW_KEY);
+      if (isViewMode(v)) return v;
+    } catch {}
+    return 'split';
+  };
+  let viewPref: ViewMode = readView();
+
+  // What actually renders: `split` isn't offered on narrow screens, so it resolves to `code` there.
+  const effectiveView = (): ViewMode => (narrow.matches && viewPref === 'split' ? 'code' : viewPref);
+
+  function applyView() {
+    const eff = effectiveView();
+    split.dataset.view = eff;
+    for (const btn of viewTabs) btn.setAttribute('aria-pressed', String(btn.dataset.view === eff));
+    // Re-fit the editor and any charts now that a pane may have just (dis)appeared.
+    editor.layout();
+    for (const card of liveCards) drawCard(card.mount, card.charts);
+  }
+
+  function setView(v: ViewMode) {
+    viewPref = v;
+    try { localStorage.setItem(VIEW_KEY, v); } catch {}
+    applyView();
+  }
+
+  for (const btn of viewTabs) {
+    btn.addEventListener('click', () => {
+      const v = btn.dataset.view;
+      if (isViewMode(v)) setView(v);
+    });
+  }
+  // Re-resolve when crossing the narrow/wide boundary (e.g. a phone rotates or a window is resized).
+  narrow.addEventListener('change', applyView);
+  applyView();
 
   // --- wiring ---
   $('pg-run').addEventListener('click', execute);

--- a/packages/www/src/components/Playground.astro
+++ b/packages/www/src/components/Playground.astro
@@ -116,7 +116,7 @@
      The Split segment is hidden on narrow screens where a two-pane split can't breathe. */
   .pg-viewtabs {
     display: inline-flex; align-items: stretch; gap: 2px;
-    padding: 2px; border: 1px solid var(--rule); border-radius: 9px; background: var(--paper-2);
+    padding: 1px; border: 1px solid var(--rule); border-radius: 8px; background: var(--paper-2);
   }
   /* The editor-toolbar copy leads the left (editor) panel and carries the toggle whenever the editor
      is shown — Code and Split. Only in Render-only, where the editor panel is gone, does the
@@ -135,9 +135,9 @@
   .pg-head-left { display: inline-flex; align-items: center; gap: 0.6rem; min-width: 0; }
   .pg-viewtab {
     font: inherit; font-size: 0.72rem; font-variant: small-caps; letter-spacing: 0.05em;
-    color: var(--ink-dim); background: transparent;
-    border: 1px solid transparent; border-radius: 7px;
-    padding: 0.2rem 0.62rem; cursor: pointer;
+    line-height: 1; color: var(--ink-dim); background: transparent;
+    border: 1px solid transparent; border-radius: 6px;
+    padding: 0.12rem 0.6rem; cursor: pointer;
     display: inline-flex; align-items: center; gap: 0.36rem;
     transition: background 0.15s ease, color 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease;
   }
@@ -194,7 +194,9 @@
     gap: 0.5rem;
     min-height: var(--pg-head, 2.3rem);
     box-sizing: border-box;
-    padding: 0.3rem 0.7rem;
+    /* Same horizontal padding as the Render header (.pg-output-head) so the view toggle sits at the
+       exact same x in both — it must not shift when the visible copy swaps between the two. */
+    padding: 0.3rem 0.85rem;
     border-bottom: 1px solid var(--rule);
     background: var(--paper);
     flex-wrap: nowrap;
@@ -211,7 +213,8 @@
     background: var(--paper-2);
     border: 1px solid var(--rule);
     border-radius: 4px;
-    padding: 0.25rem 1.7rem 0.25rem 0.6rem;
+    /* Compact vertical padding so the toolbar keeps to --pg-head and lines up with the Render header. */
+    padding: 0.12rem 1.7rem 0.12rem 0.6rem;
     cursor: pointer;
     max-width: 230px;
   }
@@ -227,7 +230,7 @@
     font: inherit;
     font-size: 0.82rem;
     border-radius: 4px;
-    padding: 0.25rem 0.65rem;
+    padding: 0.12rem 0.65rem;
     cursor: pointer;
     border: 1px solid var(--rule);
     display: inline-flex;

--- a/packages/www/src/components/Playground.astro
+++ b/packages/www/src/components/Playground.astro
@@ -353,9 +353,17 @@
     max-width: 660px; margin: 0 auto;
     font-family: var(--serif); font-size: 1.04rem; line-height: 1.62; color: var(--ink);
   }
-  /* On a wide panel, reserve a right gutter for the margin notes (text left, notes right). */
+  /* On a wide panel, reserve a right gutter for the margin notes (text left, notes right). The gutter
+     is a right padding so the text column (600) + gutter (250) form one 850-wide block that stays
+     centred — otherwise a full-width Render pane would strand the text against the right edge. */
   @container (min-width: 781px) {
-    #pg-output .pg-paper { max-width: 600px; margin-left: auto; margin-right: 250px; }
+    #pg-output .pg-paper {
+      box-sizing: border-box;
+      max-width: 850px;
+      margin-left: auto;
+      margin-right: auto;
+      padding-right: 250px;
+    }
   }
 
   /* Paper header: the frontmatter title + abstract + keywords, typeset like a journal article.

--- a/packages/www/src/components/Playground.astro
+++ b/packages/www/src/components/Playground.astro
@@ -25,13 +25,14 @@
             <span>Render</span>
           </button>
         </div>
-        <label class="pg-select-wrap">
-          <select id="pg-select" class="pg-select" aria-label="Choose an example"></select>
-        </label>
-        <button id="pg-run" class="btn btn-run" type="button">
-          <span class="btn-icon">▶</span> Run
-          <span class="kbd">⌘↵</span>
-        </button>
+        <div class="pg-toolbar-right">
+          <label class="pg-select-wrap">
+            <select id="pg-select" class="pg-select" aria-label="Choose an example"></select>
+          </label>
+          <button id="pg-run" class="btn btn-run" type="button" title="Run (⌘↵)">
+            <span class="btn-icon">▶</span> Run
+          </button>
+        </div>
       </div>
       <div id="editor" class="pg-editor"></div>
     </div>
@@ -62,7 +63,6 @@
               <span>Render</span>
             </button>
           </div>
-          <span class="pg-output-title"><span class="dot"></span> Render</span>
         </div>
         <div class="pg-head-right">
           <div id="pg-metrics" class="pg-metrics" hidden></div>
@@ -118,13 +118,20 @@
     display: inline-flex; align-items: stretch; gap: 2px;
     padding: 2px; border: 1px solid var(--rule); border-radius: 9px; background: var(--paper-2);
   }
-  /* The editor-toolbar copy sits at the toolbar's left edge and only shows when the editor is the
-     whole view (Code); in Split the Render-header copy is the visible one. */
+  /* The editor-toolbar copy leads the left (editor) panel and carries the toggle whenever the editor
+     is shown — Code and Split. Only in Render-only, where the editor panel is gone, does the
+     Render-header copy take over. So exactly one shows per view, always at the far left. */
   .pg-viewtabs-edit { display: none; }
-  .pg-split[data-view='code'] .pg-viewtabs-edit { display: inline-flex; }
-  .pg-split[data-view='split'] .pg-viewtabs-edit,
-  .pg-split[data-view='render'] .pg-viewtabs-edit { display: none; }
-  /* Left cluster of the Render header: the view toggle + the "Render" label. */
+  .pg-split[data-view='code'] .pg-viewtabs-edit,
+  .pg-split[data-view='split'] .pg-viewtabs-edit { display: inline-flex; }
+  .pg-viewtabs-out { display: none; }
+  .pg-split[data-view='render'] .pg-viewtabs-out { display: inline-flex; }
+  /* Toggle on the far left of the editor toolbar; the selector + Run ride together on the far right,
+     with the selector free to shrink so the row never wraps in the narrow split pane. */
+  .pg-toolbar-right { display: inline-flex; align-items: center; gap: 0.5rem; margin-left: auto; min-width: 0; }
+  .pg-toolbar-right .pg-select-wrap { min-width: 0; }
+  .pg-toolbar-right .pg-select { min-width: 0; }
+  /* Left cluster of the Render header: the view toggle (Render-only) + the "Render" label. */
   .pg-head-left { display: inline-flex; align-items: center; gap: 0.6rem; min-width: 0; }
   .pg-viewtab {
     font: inherit; font-size: 0.72rem; font-variant: small-caps; letter-spacing: 0.05em;
@@ -190,7 +197,7 @@
     padding: 0.3rem 0.7rem;
     border-bottom: 1px solid var(--rule);
     background: var(--paper);
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
   }
   .pg-editor { flex: 1; min-height: 0; height: auto; width: 100%; }
   @media (max-width: 880px) { .pg-editor { flex: none; height: 320px; } }
@@ -259,8 +266,6 @@
     font-size: 0.76rem; font-variant: small-caps; letter-spacing: 0.06em; color: var(--ink-dim);
     background: var(--paper);
   }
-  .pg-output-title { display: inline-flex; align-items: center; gap: 0.5rem; }
-  .pg-output-head .dot { width: 7px; height: 7px; border-radius: 50%; background: var(--accent); }
 
   .pg-output {
     margin: 0; padding: 0.85rem; flex: 1; overflow: auto;

--- a/packages/www/src/lib/share.ts
+++ b/packages/www/src/lib/share.ts
@@ -48,6 +48,8 @@ export interface ParsedHash {
   code?: string;
   /** Input overrides carried alongside `x=`/`c=` (a tuned example is shareable as tuned). */
   inputs?: Record<string, InputHashValue>;
+  /** The playground layout the link opens in: `code` | `split` | `render` (from `v=`). */
+  view?: string;
 }
 
 /** Parse the current location hash into a share target. */
@@ -57,14 +59,15 @@ export function parseHash(hash: string): ParsedHash {
   const params = new URLSearchParams(h);
   const raw = params.get('i');
   const inputs = raw ? parseInputs(raw) : undefined;
+  const view = params.get('v') ?? undefined;
   const id = params.get('x');
-  if (id) return { exampleId: id, inputs };
+  if (id) return { exampleId: id, inputs, view };
   const c = params.get('c');
   if (c) {
     const code = decodeCode(c);
-    if (code !== null) return { code, inputs };
+    if (code !== null) return { code, inputs, view };
   }
-  return { inputs };
+  return { inputs, view };
 }
 
 /** Build a shareable absolute URL: a clean `#x=id` when the code is an unmodified example,


### PR DESCRIPTION
## What & why

The playground always showed the two-pane split, which is cramped on narrow screens (editor and render can't sit side by side) and gave no way to focus on a single pane on desktop. This adds a **Code / Split / Render** view switcher and tightens the surrounding layout.

## Changes

- **View switcher** — a segmented control that switches between Code-only, Split, and Render-only layouts.
  - Lives in the header row (no dedicated bar): the copy in the **editor toolbar** carries it in Code and Split (far left of the left panel), and a copy in the **Render header** takes over in Render-only; exactly one shows per view.
  - On narrow screens the **Split** segment is hidden and a stored `split` preference falls back to a single pane, with the preference preserved for a return to a wide screen.
- **Persistence + sharing** — the chosen view is saved to `localStorage` and carried in the URL fragment as `v=` (omitted for the default Split to keep links clean, e.g. `#x=pi&v=render`). Reloads and shared links restore the view.
- **Centered render column** — the wide-panel rule that pinned the paper to a fixed right gutter stranded it against the right edge when the Render pane went full-width; the text column + margin-note gutter now form one centered block.
- **Header alignment** — matched the editor toolbar's padding to the Render header and slimmed the toggle, selector, and Run button to `--pg-head`, so the toggle keeps the same position/height across views (no shift or header growth when switching) and the two panels line up in Split.

## Verification

Built the site and drove it with Playwright across all three views: single toggle per view pinned to the left, `v=` fragment reflects/restores the view, mobile falls back correctly (Split segment hidden), the render column stays centered at any width, and the toggle holds a constant position and header height when switching Split↔Render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016anMr5o6HKTdQZtvSz7CMN