### PR TITLE
Enhance array slicing functionality and update documentation

### DIFF
--- a/.changeset/tidy-months-slice.md
+++ b/.changeset/tidy-months-slice.md
@@ -1,0 +1,11 @@
+---
+"@noiselang/core": minor
+---
+
+Array slicing: indexing with a deterministic array of indices selects into a new array. Since
+`a..b` is already an array, `xs[0..r]` takes the first `r` elements (Rust-style half-open), and
+any index list works — `xs[[2, 0, 0]]` reorders and repeats, `xs[perm]` applies a deterministic
+permutation. Each index obeys the existing scalar rules (constant non-negative integer, bounds
+checked element-wise); random indices inside the array are an error. It is pure build-time sugar
+for `[for i in inds { xs[i] }]`, so nothing changes for codegen. The secretary example's
+observation phase collapses from a fold loop to `bar = max(quality[0..r])`.

--- a/.claude/skills/noise-lang/SKILL.md
+++ b/.claude/skills/noise-lang/SKILL.md
@@ -1,23 +1,28 @@
 ---
 name: noise-lang
-description: Write correct, idiomatic Noise — an expression-based probabilistic language where every value is a probability distribution and you compute probabilities / expectations by Monte Carlo (run via the `noise` CLI). Use when authoring or editing .noise programs, or when modeling a probability / Monte-Carlo question in Noise.
+description: Write correct, idiomatic Noise — an expression-based probabilistic language where every value is a probability distribution and you compute probabilities / expectations by Monte Carlo. A .noise program compiles to a literate document — a short, live, optionally interactive article. Use when authoring or editing .noise programs, or when modeling a probability / Monte-Carlo question in Noise.
 ---
 
 # Writing Noise
 
 Noise is a small, expression-based **probabilistic** language: every value is a probability
 distribution, and you compute probabilities and expectations by Monte Carlo. A program is a
-sequence of `;`-separated statements and its result is the value of the **last** statement. This
-guide is self-contained — everything you need to write correct, idiomatic Noise is below.
+sequence of `;`-separated statements — and when compiled, it is rendered as a **document**: a
+short live article with prose, code cells, typeset math, plots, and interactive controls, in the
+spirit of a really good Jupyter notebook. You are always writing two things at once: a correct
+model, and a readable article. This guide is self-contained — the language first, then how to
+make the compiled document read well.
 
 ## Run it
 
 ```sh
-cargo run -p noise-cli -- file.noise   # run a program; prints the LAST statement's value
+cargo run -p noise-cli -- file.noise   # run a program; renders the document (prose + results) to the terminal
 cargo run -p noise-cli                 # REPL (one line at a time, persistent env)
 ```
 
-(If a `noise` binary is installed, `noise file.noise` / `noise` work the same way.)
+(If a `noise` binary is installed, `noise file.noise` / `noise` work the same way. The web
+playground renders the same document with full typography: abstract, margin notes, LaTeX,
+sliders, charts.)
 
 ## The mental model
 
@@ -51,6 +56,63 @@ Four load-bearing rules. Internalize these and the rest follows.
 
 Nothing is sampled until a query (`P`/`E`/`Var`/`Q`) forces it; everything upstream stays symbolic.
 
+## The literate layer — a program compiles to an article
+
+A run produces one flat, ordered document: frontmatter meta, then blocks (code cells, prose
+notes, plots, input controls), plus a margin-comment layer. The pieces:
+
+**Frontmatter** — an optional `---`-fenced YAML block at the very top with `title`, `abstract`,
+and `tags`. It renders as the article's title, abstract paragraph, and keywords line. **The
+abstract IS the article's introduction** — hook, setup, and the headline claim.
+
+```noise
+---
+title: "Estimate π"
+abstract: >
+  Scatter darts at random across a square and count how many land inside a circle
+  drawn in it. That fraction alone is enough to recover π.
+tags: [basics, monte carlo]
+---
+```
+
+**Code cells** — consecutive top-level statements with no blank line between them render as one
+code block. A **blank line splits cells**; a template statement also splits. Comments never
+split a cell. Group statements into cells deliberately: one cell = one step of the story.
+
+**Templates — prose and math blocks.** A triple-backtick fence with a syntax tag, written as a
+*statement*, emits a rendered block at that point in the document:
+
+    ```md
+    **The verdict.** Rejecting the first ${r} of ${n} applicants wins **${p_win * 100}%** of the time.
+    ```
+    ```latex
+    P(\text{win}) = \frac{r}{n}\sum_{k=r}^{n-1}\frac{1}{k} \approx ${p_win}
+    ```
+
+- ` ```md ` renders as body prose (full Markdown: **bold**, *italics*, inline code).
+- ` ```latex ` renders as display math (KaTeX/LaTeX source).
+- `${expr}` holes interpolate any Noise expression, evaluated in the current scope. An
+  **estimate** value (from `P`/`E`/`Var`) prints self-rounded to its justified digits.
+- A single-backtick template `` `…` `` is the inline/untagged form; in expression position a
+  template is just a string value.
+
+**Comments become margin notes.** A `//` comment run attaches to the code cell below it and
+renders as a *side note* in the margin — physically small and off to the side. That placement is
+the design constraint: margin notes are for asides, never for the narrative.
+
+**Inputs — interactive controls.** `input::real(…)` / `input::int(…)` / `input::bool(…)` declare
+a host-tunable parameter inline, with named args `min:`, `max:`, `step:`, `default:`, and
+optional `label:`/`name:`. The call evaluates to its current value (a plain number/bool), and
+the document renders a slider/checkbox at that point. Changing it re-runs the program — every
+`${…}` hole downstream updates. Use one wherever the reader should ask "what if I change this?"
+
+```noise
+r = input::int(min: 1, max: 19, step: 1, default: 7);
+```
+
+**Plots** — `plot::histogram/line/scatter/heatmap/corr/fan/…` push chart cards into the document
+at their statement's position.
+
 ## Language reference
 
 **Lexical.** Whitespace is insignificant (separates tokens). Comments are `//` (to end of line)
@@ -59,7 +121,7 @@ line 1 is allowed). Numbers are `f64` integer or decimal literals — **no expon
 leading `-` is the unary-minus operator, not part of the literal. Identifiers are
 `[A-Za-z_][A-Za-z0-9_]*`, case-sensitive. Reserved words: `if else for in use true false`.
 Strings are double-quoted with **no escape sequences** (`"like this"`); they are a label/utility
-type for `Print` and messages — a string can never enter a random-variable expression.
+type — a string can never enter a random-variable expression.
 
 **Operators** (precedence low → high; all left-associative except `^` and binding, which are
 right-associative; prefix `-`/`!` bind tighter than everything below `^`, so `-2 ^ 2 == -4`):
@@ -96,19 +158,20 @@ carrying a standard error, produced by `P`/`E`/`Var`), and `signal` (a lazy wave
 
 ## Modules & `use`
 
-`builtin` is **always active**: `P`, `Q`, `E`, `Var`, `Print`, `Len` (capitalized). Everything
+`builtin` is **always active**: `P`, `Q`, `E`, `Var`, `Len` (capitalized). Everything
 else is **strict** — a bare name errors until you `use` its module (or write the `mod::name`
 path). Start each program with the `use` lines you need.
 
 | Module    | `use`?   | Items |
 |-----------|----------|-------|
-| `builtin` | always   | `P`, `Q`, `E`, `Var`, `Print`, `Len` |
+| `builtin` | always   | `P`, `Q`, `E`, `Var`, `Len` |
 | `rand`    | `use rand;` | `unif`, `unif_int`, `bernoulli`, `normal`, `normal_int`, `normal_complex`, `exponential`, `exponential_int`, `poisson`, `geometric`, `categorical`, `empirical`, `block_bootstrap`, `rotation`, `permutation` |
 | `math`    | `use math;` | `pi`, `e`, `i`/`j` (imaginary unit), `sqrt`, `exp`, `abs`, `arg`, `conj`, `re`, `im`, `floor`, `ceil`, `round`, `log` (natural), `log10`, `sin`, `cos`, `atan`, `sign`, `gcd`, `modpow` — `exp`/`log`/`log10` lift over RVs like `sin`/`cos` |
 | `vec`     | `use vec;`  | `sum`, `prod`, `count`, `any`, `all`, `max`, `min`, `mean`, `cumsum`, `cumprod`, `cummax`, `cummin`, `dot`, `vdot`, `normsq`, `norm`, `transpose`, `adjoint`, `normalize`, `outer`, `quantize`, `has_duplicates`, `count_duplicates`, `mse`, `ones`, `zeros`, `iota` |
 | `signal`  | `use signal;` | `sine`, `cosine`, `sample`, `noise_white`, `noise_white_complex`, `noise_brown`, `noise_pink`, `noise_ou` |
-| `plot`    | path-only | `histogram`, `line`, `scatter`, `heatmap`, `corr`, `fan` (quantile-band cone of a path), `explain`, `value` — write the path (`plot::fan(...)`); charts are pushed to the output stream like `Print` |
+| `plot`    | path-only | `histogram`, `line`, `scatter`, `heatmap`, `corr`, `fan` (quantile-band cone of a path), `explain`, `value` — write the path (`plot::fan(...)`); charts are pushed into the document at their statement's position |
 | `stats`   | path-only | `histogram(x[, bins])` → `[[midpoints],[counts]]`, `quantiles(x, [q…])`, `moments(x)` → `[n, mean, sd, min, max]`, `fan(path)` → 6×cols (`q05,q25,q50,q75,q95,mean`), `corr(a, b)` → number / `corr(v)` → n×n matrix. The numbers behind the `plot::` charts — same computation, so `stats::quantiles(x, [0.05])[0]` *is* the `q05` the card prints. Forces sampling; takes `x | cond`. |
+| `input`   | path-only | `real`, `int`, `bool` — inline tunable parameters (see the literate layer above) |
 | `engine`  | `use engine;` (or path) | `set_max_samples`, `set_max_opts`, `set_resolution` |
 
 ```noise
@@ -121,18 +184,22 @@ A user definition shadows a module item of the same name. Module paths are singl
 
 ## The standard workflow
 
-recipe (`=`) → draw (`~` / `~[n]`) → transform (`=`) → query (`P`/`E`/`Var`/`Q`) → `Print`.
+recipe (`=`) → draw (`~` / `~[n]`) → transform (`=`) → query (`P`/`E`/`Var`/`Q`) → present
+through ```md / ```latex templates (see "Writing the article"). In the REPL the last statement's
+value prints by itself.
 
-```noise
-use rand;   // unif_int
-use vec;    // has_duplicates
+    use rand;   // unif_int
+    use vec;    // has_duplicates
 
-n     = 23;
-bday  = unif_int(1, 365);   // a recipe
-days  ~[n] bday;            // n independent draws
-match = has_duplicates(days);
-Print("P(shared birthday among", n, ") =", P(match))
-```
+    class_size = 23;
+    birthday   = unif_int(1, 365);        // a recipe
+    birthdays  ~[class_size] birthday;    // class_size independent draws
+    shared     = has_duplicates(birthdays);
+    p_shared   = P(shared);
+
+    ```md
+    A class of ${class_size} shares a birthday **${p_shared * 100}%** of the time.
+    ```
 
 ## Distributions & queries
 
@@ -171,7 +238,8 @@ Print("P(shared birthday among", n, ") =", P(match))
 - `P(event[, n])` — probability a bool-RV is true. Returns an **estimate** carrying its standard
   error: it **self-rounds to the digits the sample size justifies**, and the error **propagates
   through arithmetic** (`4 * P(C)` shows one fewer digit). Pass a bigger `n` to reveal more digits.
-  `P` of a non-event (numeric) is an error.
+  A fractional second argument (`P(hit, 1e-4)`) asks for **precision** instead of a sample count —
+  the engine keeps sampling until the answer is that good. `P` of a non-event (numeric) is an error.
 - `E(x[, n])` / `Var(x[, n])` — expectation / variance of a numeric (or bool) quantity. `E` of a
   bool equals `P`.
 - `Q(x, q[, n])` — quantile (inverse CDF): `Q(X, 0.5)` median, `Q(X, 0.95)` 95th pct, `Q(X, 0)` /
@@ -182,7 +250,6 @@ Print("P(shared birthday among", n, ") =", P(match))
   `X | C` is also a **first-class value**: bind it (`hi = D | D > 3`), query it later (`P(hi < 5)`),
   and operate on it (`2*(X|C)+1` is `(2X+1) | C`). You **cannot** combine two values conditioned on
   *different* events — condition once, at the end (`(X + Y) | C`).
-- `Print(args…)` — space-separated, then newline; combine with string `+` and `round(x, d)`.
 - `Len(xs)` — element count of an array (a build-time constant).
 
 ## Collections, arrays & idioms
@@ -192,7 +259,10 @@ the range `a..b` (half-open: `0..n` is `0 … n-1`), the shaped draw `~[n] d`, o
 constructors (`ones(n)`, `zeros(n)`, `iota(n)`). Index with `xs[i]` (chains: `M[i][j]`); the index
 is normally a **constant non-negative integer in range** — a *random* numeric index lifts to a
 per-lane **gather** (each lane picks its own element; interpreter-only, not codegen-eligible). There is no
-append/push.
+append/push. A deterministic **array** of indices **slices**: `xs[0..r]` takes the first `r`
+elements (so `max(quality[0..r])` is "the best of the first r"), `xs[[2, 0, 0]]` reorders/repeats,
+`xs[perm]` applies a deterministic permutation — sugar for `[for i in inds { xs[i] }]`; random
+indices inside the array are an error.
 
 **Arithmetic broadcasts** over arrays (NumPy-style, nesting for matrices):
 `[1,2,3] + [10,20,30]` → `[11,22,33]`, `1 + [1,2,3]` → `[2,3,4]`, `[1,2,3] ^ 2` → `[1,4,9]`.
@@ -205,10 +275,10 @@ a `vec` reducer — independence becomes a one-liner:
 
 ```noise
 use rand; use vec;
-dice  ~[2] unif_int(1, 6); Print("P(sum==7) =", P(sum(dice) == 7))      // two dice
-flips ~[3] bernoulli(0.5); Print("P(all heads) =", P(all(flips)))       // 3-coin streak
-flips ~[3] bernoulli(0.5); Print("P(exactly 2) =", P(count(flips)==2))  // count of true
-parts ~[3] bernoulli(0.9); Print("uptime =", P(any(parts)))             // at-least-one
+dice  ~[2] unif_int(1, 6);  p_seven    = P(sum(dice) == 7);       // two dice
+flips ~[3] bernoulli(0.5);  p_streak   = P(all(flips));           // 3-coin streak
+p_two_heads = P(count(flips) == 2);                               // count of true
+parts ~[3] bernoulli(0.9);  p_uptime   = P(any(parts));           // at-least-one
 ```
 
 **Paths & finance idioms (scans).** The scans `cumsum`/`cumprod`/`cummax`/`cummin` (running
@@ -226,8 +296,8 @@ asian    = mean(path);                      // Asian option averages the path
 lookback = max(path);                       // lookback takes its peak
 drawdown = min(path / cummax(path)) - 1;    // worst peak-to-trough
 final = path[251];
-var = Q(final, 0.05);                       // VaR — Q returns a plain number...
-Print("VaR95 =", var, " ES95 =", E(final | final < var));  // ...so it feeds ES/CVaR
+var95 = Q(final, 0.05);                     // VaR — Q returns a plain number...
+es95  = E(final | final < var95);           // ...so it feeds ES/CVaR
 plot::fan(path)                             // the cone: q05/25/50/75/95 bands over the index
 bands = stats::fan(path);                   // ...and the same bands as a 6×252 matrix
 ```
@@ -241,7 +311,7 @@ evaluated and reuse the condition's per-lane draws). Gives `max`/`min`/`abs` ove
 ```noise
 A ~ unif_int(1, 6); B ~ unif_int(1, 6);
 higher = if A > B { A } else { B };     // max of two dice
-Print("P(higher==6) =", P(higher == 6))
+p_six  = P(higher == 6)
 ```
 
 **Ranges & `for` (build-time unroll).** `for x in xs { }` runs the body once per element; **bindings
@@ -287,9 +357,9 @@ hand-written ratio:
 ```noise
 use rand;
 D ~ unif_int(1, 6);
-Print("P(D==6 | D>3) =", P(D == 6 | D > 3))               // = 1/3 (≡ P(A && C) / P(C))
-hi = D | D > 3;                                           // a conditioned value — bind & reuse
-Print("E(roll | >3)  =", E(hi), " median:", Q(hi, 0.5))   // 5, 5
+p_six_given_high = P(D == 6 | D > 3);   // = 1/3 (≡ P(A && C) / P(C))
+high = D | D > 3;                       // a conditioned value — bind & reuse
+mean_high = E(high); median_high = Q(high, 0.5)   // 5, 5
 ```
 
 **Signals (lazy waveforms).** `signal::sine(f)` / `cosine(f)` describe a waveform by frequency
@@ -359,21 +429,109 @@ static ~[64] rand::normal_complex(1);    // 64 iid complex-Gaussian static sampl
   inference: conditioning on a continuous measurement (`X == 4.7`, probability ~0) or a rare event
   won't work; that's the separate inference track.
 
-## Style conventions
+## Writing the article
 
-- Open with a comment stating the question and, where one exists, the analytic answer to check
-  against.
-- Use **readable, named intermediate steps**, not nested one-liners (`days`, `match`, `total`,
-  `higher` — one idea per binding).
-- Put the needed `use` lines at the top.
-- **End in `Print(...)`**, building the message with string `+` and `round(x, d)`.
+A finished `.noise` example must read, compiled, like a short live article — a really good
+notebook. The recipe (converged on `examples/pi.noise` and `examples/secretary.noise`; read those
+two as the canonical models):
+
+**Structure**
+
+- **The abstract is the introduction.** Hook, setup, headline claim — in the frontmatter. Never
+  open the body with an ```md block that restates it.
+- **One cell = one step of the story.** Split cells with blank lines deliberately. Give each code
+  cell a SHORT ```md lead-in (1–3 sentences) that advances the story at the idea/math/game level.
+  Bare code with nothing between cells is as wrong as walls of prose.
+- **Open each md lead-in with a bold step name** — `**The pool.**`, `**Observation phase.**`,
+  `**The verdict.**` — so the article skeleton is scannable. Italics for key terms.
+- **Structure the code for the narrative.** Unwrap helper functions so each phase of the model is
+  its own cell in reading order (pool → cutoff → observe → hire → verdict), rather than one
+  `trial()` blob. No orphan cells (`n = 20;` alone between prose) — group constants with the cell
+  that uses them, or inline them.
+- **End with a verdict.** A closing ```md that weaves the computed result into a sentence, plus —
+  when a law/closed form exists — a ```latex display of it.
+
+**Prose discipline**
+
+- md prose must ADD something: the idea, the math, the rules of the game. Never narrate what code
+  lines do — a comment or sentence that paraphrases code is an excuse for unclear code
+  (clean-code rule); rename variables or restructure instead.
+- **Margin comments (`//`) are rare asides**: at most 1–2 per file, each saying something the code
+  *can't* (e.g. "1e-4 asks for precision, not a draw count", or a quip beside a plot). If it's
+  narrative, it belongs in an ```md block; if it's obvious, delete it.
+- **Sentence-like variable names** make the code read as prose: `win = hired_candidate ==
+  best_candidate`, `quality`, `bar` — not `c`, `pk`, `tmp`.
+
+**Live numbers**
+
+- **Never hardcode a result in prose or comments — the whole point is that it's computed.** Every
+  number a reader sees must come from a `${…}` hole so it tracks sliders and parameter edits.
+  Symbolic constants (π/4, 1/e, r = n/e) are fine as *symbols*.
+- **Templates hold references, not expressions.** Compute in code (`p_win = P(win);`), then
+  interpolate `${p_win * 100}` — trivial arithmetic in a hole is fine, big expressions are not.
+- **Don't re-derive the analytic answer numerically in a hole** (no `${sum([for k in r..n
+  {1/k}]) * …}`) — that's not the point of Noise. State the law symbolically in latex and let the
+  simulation supply the number. The canonical latex shape is **symbolic law ≈ ${simulated}**:
+  `\pi \approx 4 \cdot P(X^2+Y^2<1) = ${pi}`, or
+  `P(\text{win}) = \frac{r}{n}\sum_{k=r}^{n-1}\frac{1}{k} \approx ${p_win}`. Cheap *locations* of
+  a law are fine to compute (`r = \frac{n}{e} \approx ${math::round(n / math::e, 0)}`).
+- **Make it interactive where a parameter invites play**: an `input::` slider on the quantity the
+  reader will wonder about ("what if I observe more first?"), with the verdict recomputing live.
+
+**A compiled-article skeleton** (abridged from `examples/secretary.noise`):
+
+    ---
+    title: "The secretary problem"
+    abstract: >
+      You interview applicants one at a time … about 37% of the time.
+    tags: [classic, optimal stopping]
+    ---
+
+    use vec;
+
+    ```md
+    **The pool.** Twenty applicants walk in, one at a time, each with a hidden
+    quality score. Nothing short of hiring the *best of all of them* counts.
+    ```
+    total_candidates = 20;
+    quality ~[total_candidates] rand::unif(0, 1);
+    best_candidate = max(quality);
+
+    ```md
+    **The cutoff.** The whole strategy hinges on one number … Try dragging **r**.
+    ```
+    r = input::int(min: 1, max: 19, step: 1, default: 7);
+
+    … observation & hiring cells, each with a bold md lead-in …
+    win   = hired_candidate == best_candidate;
+    p_win = P(win);
+
+    ```md
+    **The verdict.** Rejecting the first ${r} of ${total_candidates} lands the very
+    best applicant **${p_win * 100}%** of the time…
+    ```
+    ```latex
+    P(\text{win}) = \frac{r}{n}\sum_{k=r}^{n-1}\frac{1}{k} \approx ${p_win},
+    \qquad \text{maximized at } r = \frac{n}{e} \approx ${math::round(total_candidates / math::e, 0)}
+    ```
 
 ## Pre-flight checklist
 
 - [ ] Every random variable is introduced with `~` (no arithmetic on a bare recipe).
 - [ ] Independence comes from `~[n]` or separate `~` — not from repeating a name.
 - [ ] Equality / counting uses a **discrete** distribution (`unif_int`/`bernoulli`/`*_int`).
-- [ ] `use` lines present for every non-`builtin` name; queries are capitalized (`P`/`E`/`Var`/`Q`/`Print`/`Len`).
+- [ ] `use` lines present for every non-`builtin` name; queries are capitalized (`P`/`E`/`Var`/`Q`/`Len`).
 - [ ] No random-length / early-stopping recurrence (fixed-horizon paths via scans are fine), no
       expectation of block scoping.
-- [ ] Program ends in `Print(...)`; run it and sanity-check against the analytic value.
+- [ ] Run it and sanity-check the result against the analytic value.
+
+For an example/demo (the article form), additionally:
+
+- [ ] Frontmatter with title + abstract; the abstract is the intro and is never restated.
+- [ ] Each code cell has a short bold-led ```md lead-in that adds idea/math, not code narration.
+- [ ] At most 1–2 margin `//` comments, each saying something the code can't.
+- [ ] No number appears in prose that isn't a `${…}` hole (symbols like 1/e are fine); templates
+      reference precomputed variables; no closed-form re-derivations in holes.
+- [ ] Ends with a verdict ```md (and a ```latex `law ≈ ${simulated}` when a law exists).
+- [ ] Rendered check: cells alternate prose/code cleanly, no orphan blocks, sliders where play is
+      natural.

--- a/.claude/skills/noise-lang/SKILL.md
+++ b/.claude/skills/noise-lang/SKILL.md
@@ -7,7 +7,7 @@ description: Write correct, idiomatic Noise — an expression-based probabilisti
 
 Noise is a small, expression-based **probabilistic** language: every value is a probability
 distribution, and you compute probabilities and expectations by Monte Carlo. A program is a
-sequence of `;`-separated statements — and when compiled, it is rendered as a **document**: a
+sequence of statements, one per line — and when compiled, it is rendered as a **document**: a
 short live article with prose, code cells, typeset math, plots, and interactive controls, in the
 spirit of a really good Jupyter notebook. You are always writing two things at once: a correct
 model, and a readable article. This guide is self-contained — the language first, then how to
@@ -107,13 +107,20 @@ the document renders a slider/checkbox at that point. Changing it re-runs the pr
 `${…}` hole downstream updates. Use one wherever the reader should ask "what if I change this?"
 
 ```noise
-r = input::int(min: 1, max: 19, step: 1, default: 7);
+r = input::int(min: 1, max: 19, step: 1, default: 7)
 ```
 
 **Plots** — `plot::histogram/line/scatter/heatmap/corr/fan/…` push chart cards into the document
 at their statement's position.
 
 ## Language reference
+
+**Statements.** A statement normally ends at the end of its line — do NOT write trailing
+semicolons. `;` exists for exactly two cases: separating several statements on one line
+(`p = 1; q = N`, a one-line block body `{ acc = 0; for … }`), and guarding the one ambiguity —
+a line that *starts* with `[` continues the previous expression as an *index*, so a statement
+before a line like `[for p in QFT @ Psi { … }]` or `[p, q]` must end in `;`. Multi-line
+expressions (arrays, function bodies, chained `+`/`*` continuations) work without any marker.
 
 **Lexical.** Whitespace is insignificant (separates tokens). Comments are `//` (to end of line)
 or `/* … */` (block, non-nesting) — `#` is **not** a comment marker (only a `#!` shebang on
@@ -175,7 +182,7 @@ path). Start each program with the `use` lines you need.
 | `engine`  | `use engine;` (or path) | `set_max_samples`, `set_max_opts`, `set_resolution` |
 
 ```noise
-use rand;            // unif, unif_int, …
+use rand            // unif, unif_int, …
 math::sqrt(2)        // or reach one item by its full path, no `use` needed
 ```
 
@@ -188,14 +195,14 @@ recipe (`=`) → draw (`~` / `~[n]`) → transform (`=`) → query (`P`/`E`/`Var
 through ```md / ```latex templates (see "Writing the article"). In the REPL the last statement's
 value prints by itself.
 
-    use rand;   // unif_int
-    use vec;    // has_duplicates
+    use rand   // unif_int
+    use vec    // has_duplicates
 
-    class_size = 23;
-    birthday   = unif_int(1, 365);        // a recipe
-    birthdays  ~[class_size] birthday;    // class_size independent draws
-    shared     = has_duplicates(birthdays);
-    p_shared   = P(shared);
+    class_size = 23
+    birthday   = unif_int(1, 365)        // a recipe
+    birthdays  ~[class_size] birthday    // class_size independent draws
+    shared     = has_duplicates(birthdays)
+    p_shared   = P(shared)
 
     ```md
     A class of ${class_size} shares a birthday **${p_shared * 100}%** of the time.
@@ -243,7 +250,8 @@ value prints by itself.
 - `E(x[, n])` / `Var(x[, n])` — expectation / variance of a numeric (or bool) quantity. `E` of a
   bool equals `P`.
 - `Q(x, q[, n])` — quantile (inverse CDF): `Q(X, 0.5)` median, `Q(X, 0.95)` 95th pct, `Q(X, 0)` /
-  `Q(X, 1)` min/max draw. Returns a plain number.
+  `Q(X, 1)` min/max draw. Returns an estimate (self-rounding, like `P`/`E`/`Var`) whose standard
+  error comes from the order-statistic band — density-free.
 - **`event | given` — conditioning** (Bayes, scoped to one query, no `observe`/side effect):
   `P(A | C)` is "P(A) given C holds", `E(X | C)` / `Q(X | C, q)` likewise. The `|` binds looser than
   everything (below `||`). `given` must be an event; for `P`, the left side must be an event too.
@@ -274,11 +282,11 @@ mapped over arrays).
 a `vec` reducer — independence becomes a one-liner:
 
 ```noise
-use rand; use vec;
-dice  ~[2] unif_int(1, 6);  p_seven    = P(sum(dice) == 7);       // two dice
-flips ~[3] bernoulli(0.5);  p_streak   = P(all(flips));           // 3-coin streak
-p_two_heads = P(count(flips) == 2);                               // count of true
-parts ~[3] bernoulli(0.9);  p_uptime   = P(any(parts));           // at-least-one
+use rand; use vec
+dice  ~[2] unif_int(1, 6);  p_seven    = P(sum(dice) == 7)       // two dice
+flips ~[3] bernoulli(0.5);  p_streak   = P(all(flips))           // 3-coin streak
+p_two_heads = P(count(flips) == 2)                               // count of true
+parts ~[3] bernoulli(0.9);  p_uptime   = P(any(parts))           // at-least-one
 ```
 
 **Paths & finance idioms (scans).** The scans `cumsum`/`cumprod`/`cummax`/`cummin` (running
@@ -286,20 +294,20 @@ folds: element `t` is the fold of `xs[0..=t]`) turn a shaped draw into a whole *
 path** — no loop needed:
 
 ```noise
-use rand; use vec; use math;
-rets ~[252] normal(0.0004, 0.01);          // a year of iid daily returns
-walk = cumsum(rets);                        // random walk = cumsum(increments)
-path = cumprod(1 + rets);                   // compounding wealth path
+use rand; use vec; use math
+rets ~[252] normal(0.0004, 0.01)          // a year of iid daily returns
+walk = cumsum(rets)                        // random walk = cumsum(increments)
+path = cumprod(1 + rets)                   // compounding wealth path
 // exact GBM, no discretization bias:  path = s0 * exp(cumsum(logrets))
-hit      = any(path < 0.9);                 // barrier: did it EVER dip 10%?
-asian    = mean(path);                      // Asian option averages the path
-lookback = max(path);                       // lookback takes its peak
-drawdown = min(path / cummax(path)) - 1;    // worst peak-to-trough
-final = path[251];
-var95 = Q(final, 0.05);                     // VaR — Q returns a plain number...
-es95  = E(final | final < var95);           // ...so it feeds ES/CVaR
+hit      = any(path < 0.9)                 // barrier: did it EVER dip 10%?
+asian    = mean(path)                      // Asian option averages the path
+lookback = max(path)                       // lookback takes its peak
+drawdown = min(path / cummax(path)) - 1    // worst peak-to-trough
+final = path[251]
+var95 = Q(final, 0.05)                     // VaR — a numeric estimate...
+es95  = E(final | final < var95)           // ...that feeds straight into ES/CVaR
 plot::fan(path)                             // the cone: q05/25/50/75/95 bands over the index
-bands = stats::fan(path);                   // ...and the same bands as a 6×252 matrix
+bands = stats::fan(path)                   // ...and the same bands as a 6×252 matrix
 ```
 
 `vec::prod` is the product reducer (`prod([]) == 1`). Scans work on any process whose **length
@@ -309,8 +317,8 @@ is known up front**; a random-length process is not expressible (see Hazards).
 evaluated and reuse the condition's per-lane draws). Gives `max`/`min`/`abs` over RVs for free:
 
 ```noise
-A ~ unif_int(1, 6); B ~ unif_int(1, 6);
-higher = if A > B { A } else { B };     // max of two dice
+A ~ unif_int(1, 6); B ~ unif_int(1, 6)
+higher = if A > B { A } else { B }     // max of two dice
 p_six  = P(higher == 6)
 ```
 
@@ -319,7 +327,7 @@ leak** (blocks don't scope) — that's exactly how an accumulator persists. Each
 is a *distinct* node, so it's a clean way to make many independent draws:
 
 ```noise
-use vec;
+use vec
 acc = 0; for x in 1..5 { acc = acc + x }; acc      // 1+2+3+4 = 10
 ```
 
@@ -329,9 +337,9 @@ has no closures, so this is how you "map with captured state"). Use **`continue`
 element — that's how you *filter*:
 
 ```noise
-a = 7; N = 15;
-fx = [for x in 0..6 { (a ^ x) % N }];                  // body closes over a, N
-evens = [for x in 0..10 { if x % 2 != 0 { continue }; x }];  // filter via continue
+a = 7; N = 15
+fx = [for x in 0..6 { (a ^ x) % N }]                  // body closes over a, N
+evens = [for x in 0..10 { if x % 2 != 0 { continue }; x }]  // filter via continue
 ```
 
 `continue` skips the rest of the loop body (in a `for` loop it drops that iteration's side effects;
@@ -343,9 +351,9 @@ for `n > 0` (clock/modular arithmetic): `-1 % 3 == 2`. `math::floor` / `math::ce
 **User functions.** `f(a) = expr` is pure (lifts over RVs); `f() ~ dist` draws fresh per call:
 
 ```noise
-use rand;
-max(a, b) = if a > b { a } else { b };   // pure
-roll() ~ unif_int(1, 6);                 // fresh draw each call
+use rand
+max(a, b) = if a > b { a } else { b }   // pure
+roll() ~ unif_int(1, 6)                 // fresh draw each call
 P(roll() + roll() == 7)                  // two INDEPENDENT rolls
 ```
 Functions are **pure in their parameters** — the body sees only its args (plus `pi`/`e`), no outer
@@ -355,10 +363,10 @@ variables, no closures. Calls unroll at build time, so recursion must terminate.
 hand-written ratio:
 
 ```noise
-use rand;
-D ~ unif_int(1, 6);
-p_six_given_high = P(D == 6 | D > 3);   // = 1/3 (≡ P(A && C) / P(C))
-high = D | D > 3;                       // a conditioned value — bind & reuse
+use rand
+D ~ unif_int(1, 6)
+p_six_given_high = P(D == 6 | D > 3)   // = 1/3 (≡ P(A && C) / P(C))
+high = D | D > 3                       // a conditioned value — bind & reuse
 mean_high = E(high); median_high = Q(high, 0.5)   // 5, 5
 ```
 
@@ -379,11 +387,11 @@ static with `E|z|² = sigma²` — combine with `math::exp(i*θ)`/`abs`/`arg` fo
 modulate → demodulate chain.
 
 ```noise
-use signal;
-engine::set_resolution(64);        // the one resolution knob — set once, next to the budget
-msg = 0.3 * sine(3);               // a waveform (no length anywhere in the math)
-static ~ noise_white_complex(0.4); // ONE drawn realization of complex static
-err = E(vec::mse(math::abs(1 + msg + static) - 1, msg));   // reducers render at the knob
+use signal
+engine::set_resolution(64)        // the one resolution knob — set once, next to the budget
+msg = 0.3 * sine(3)               // a waveform (no length anywhere in the math)
+static ~ noise_white_complex(0.4) // ONE drawn realization of complex static
+err = E(vec::mse(math::abs(1 + msg + static) - 1, msg))   // reducers render at the knob
 ```
 
 **Complex numbers.** `complex` is a first-class scalar. There's no literal — it **emerges** from
@@ -396,11 +404,11 @@ err = E(vec::mse(math::abs(1 + msg + static) - 1, msg));   // reducers render at
 `dot` is bilinear while `vdot` conjugates (Hermitian), plus `outer` and `adjoint`.
 
 ```noise
-use math; use rand; use vec;
-z = 2 + 3*math::i;                       // complex emerges from math::i
-math::abs(z); math::arg(z);              // magnitude & phase (reals)
+use math; use rand; use vec
+z = 2 + 3*math::i                       // complex emerges from math::i
+math::abs(z); math::arg(z)              // magnitude & phase (reals)
 math::exp(math::i * math::pi)            // ≈ -1  (Euler's identity)
-static ~[64] rand::normal_complex(1);    // 64 iid complex-Gaussian static samples
+static ~[64] rand::normal_complex(1)    // 64 iid complex-Gaussian static samples
 ```
 
 ## Hazards — what NOT to do
@@ -469,6 +477,9 @@ two as the canonical models):
   Symbolic constants (π/4, 1/e, r = n/e) are fine as *symbols*.
 - **Templates hold references, not expressions.** Compute in code (`p_win = P(win);`), then
   interpolate `${p_win * 100}` — trivial arithmetic in a hole is fine, big expressions are not.
+- **Queries self-round; deterministic arithmetic doesn't.** `P`/`E`/`Var`/`Q` all return
+  estimates that print the digits their sample justifies. A *deterministic* computation
+  (`mean(rets)`, a folded constant) prints full float junk — wrap those holes in `round(x, d)`.
 - **Don't re-derive the analytic answer numerically in a hole** (no `${sum([for k in r..n
   {1/k}]) * …}`) — that's not the point of Noise. State the law symbolically in latex and let the
   simulation supply the number. The canonical latex shape is **symbolic law ≈ ${simulated}**:
@@ -487,24 +498,24 @@ two as the canonical models):
     tags: [classic, optimal stopping]
     ---
 
-    use vec;
+    use vec
 
     ```md
     **The pool.** Twenty applicants walk in, one at a time, each with a hidden
     quality score. Nothing short of hiring the *best of all of them* counts.
     ```
-    total_candidates = 20;
-    quality ~[total_candidates] rand::unif(0, 1);
-    best_candidate = max(quality);
+    total_candidates = 20
+    quality ~[total_candidates] rand::unif(0, 1)
+    best_candidate = max(quality)
 
     ```md
     **The cutoff.** The whole strategy hinges on one number … Try dragging **r**.
     ```
-    r = input::int(min: 1, max: 19, step: 1, default: 7);
+    r = input::int(min: 1, max: 19, step: 1, default: 7)
 
     … observation & hiring cells, each with a bold md lead-in …
-    win   = hired_candidate == best_candidate;
-    p_win = P(win);
+    win   = hired_candidate == best_candidate
+    p_win = P(win)
 
     ```md
     **The verdict.** Rejecting the first ${r} of ${total_candidates} lands the very

--- a/LANG.md
+++ b/LANG.md
@@ -837,6 +837,13 @@ just an array of `dist`.
   a per-lane **gather** — each Monte Carlo lane picks its own element (`boxes[box]` in
   `prisoners.noise`, and the machinery under `rand::empirical`). Gathers run on the interpreter
   only (the codegen backends decline them).
+- **Slicing.** A deterministic **array** of indices selects into a new array. Since `a..b` is an
+  array, `xs[0..r]` is the first-`r` slice (Rust-style half-open — the same shape as Rust's
+  `&xs[0..r]` or Julia's `xs[inds]`), and any index list works: `xs[[2, 0, 0]]` reorders and
+  repeats, `xs[perm]` applies a deterministic permutation. Each index obeys the scalar rules
+  (constant non-negative integer, in bounds — checked element-wise), so an array of *random*
+  indices is an error. It is pure build-time sugar for `[for i in inds { xs[i] }]`:
+  `bar = max(quality[0..r])` is "the best of the first `r`".
 - **Arithmetic broadcasts over arrays** (NumPy-style): `[1,2,3] + [10,20,30] = [11,22,33]`,
   `1 + [1,2,3] = [2,3,4]`, `[2,4,6] / 2 = [1,2,3]`, `[1,2,3] ^ 2 = [1,4,9]`. It nests, so an
   array-of-arrays (a matrix, or an `[I, Q]` signal pair) broadcasts recursively. Lengths must match.

--- a/crates/noise-core/src/builtins.rs
+++ b/crates/noise-core/src/builtins.rs
@@ -559,8 +559,10 @@ fn moment(name: &str, arg_vals: &[Value], ctx: &QueryCtx) -> Result<Value> {
 /// central) — then sort and linearly interpolate between the two bracketing order statistics. A
 /// deterministic value is its own quantile at every level.
 ///
-/// Returns a plain `Num` (not an `Est`): a sample quantile's standard error depends on the density
-/// at that point, so we don't claim auto-rounded precision the way `P`/`E` do.
+/// Returns an `Est` like `P`/`E`/`Var`, so the printed digits are the ones the sample justifies.
+/// The standard error is density-free ([`crate::num::quantile_se_sorted`]): the quantile's rank is
+/// Binomial(n, q), so the spread between the order statistics one rank-sd apart is a ±1σ band —
+/// no density estimate needed. A deterministic input still returns a plain `Num` (exact).
 ///
 /// Note: `P` and `Q` on the *same* underlying event/quantity each force their **own independent
 /// sampling pass** over a *different* cone — an event-indicator graph for `P`, the numeric quantity
@@ -608,17 +610,18 @@ fn quantile(arg_vals: &[Value], ctx: &QueryCtx) -> Result<Value> {
         Value::Dist(id) => {
             // Validate-only mode: the quantity's graph is built and type-checked; skip sampling.
             if check {
-                return Ok(Value::Num(0.0));
+                return Ok(Value::Est { val: 0.0, se: 0.0 });
             }
-            // `Q` keeps fixed-n (PLAN-PRECISION "out of scope": the collect reducer is O(n) memory
-            // and a quantile's se needs a density estimate). A soft-stopped collect is a smaller —
-            // still valid — sample; the run-level warning names the stop.
+            // `Q` keeps fixed-n (PLAN-PRECISION "out of scope": the collect reducer is O(n)
+            // memory). A soft-stopped collect is a smaller — still valid — sample; the run-level
+            // warning names the stop.
             let mut draws = sampler::sample_n_par(graph, *id, n, P_DEFAULT_SEED)?;
             if draws.is_empty() {
                 return Err(stopped_before_draws("Q", span));
             }
             draws.sort_by(f64::total_cmp);
-            Ok(Value::Num(crate::num::quantile_sorted(&draws, q)))
+            let (val, se) = quantile_est(&draws, q);
+            Ok(Value::Est { val, se })
         }
         other => Err(NoiseError::runtime(
             format!(
@@ -756,7 +759,7 @@ pub fn quantile_cond(root: RvId, tail: &[Value], ctx: &QueryCtx) -> Result<Value
         ));
     }
     if check {
-        return Ok(Value::Num(0.0));
+        return Ok(Value::Est { val: 0.0, se: 0.0 });
     }
     // `Q` takes counts only (see `quantile` — quantiles are out of the precision loop's scope).
     let n = match tail.get(1) {
@@ -777,7 +780,21 @@ pub fn quantile_cond(root: RvId, tail: &[Value], ctx: &QueryCtx) -> Result<Value
         return Err(cond_never(n, span));
     }
     draws.sort_by(f64::total_cmp);
-    Ok(Value::Num(crate::num::quantile_sorted(&draws, q)))
+    let (val, se) = quantile_est(&draws, q);
+    Ok(Value::Est { val, se })
+}
+
+/// Quantile value + standard error from **sorted, non-empty** draws, shared by `Q` and
+/// `Q(x | cond, q)`. The se is the density-free order-statistic band
+/// ([`crate::num::quantile_se_sorted`]), floored at the sampling lanes' resolution: lanes sample
+/// in f32, so a collected draw carries ~1e-7 *relative* float dust, and on a quantile plateau
+/// (discrete/empirical data) the band collapses to 0 — which would print that dust as if it were
+/// exact digits. The floor makes the display round the dust away instead of exhibiting it.
+fn quantile_est(sorted: &[f64], q: f64) -> (f64, f64) {
+    const LANE_RESOLUTION_REL: f64 = 2e-6;
+    let val = crate::num::quantile_sorted(sorted, q);
+    let se = crate::num::quantile_se_sorted(sorted, q).max(val.abs() * LANE_RESOLUTION_REL);
+    (val, se)
 }
 
 /// `iota(n)` — `[0, 1, …, n-1]` (the same array as `0..n`; a handy alias).
@@ -962,6 +979,10 @@ fn as_num(v: &Value, span: Span) -> Result<f64> {
     match v {
         Value::Num(n) => Ok(*n),
         Value::Est { val, .. } => Ok(*val),
+        // A symbolic input (`input::real`) in a context that needs a concrete number folds to its
+        // current value — the *structural* materialization (see `crate::sym`): `round(slider, 2)`
+        // legitimately depends on the slider, and the folded constant rebuilds on change.
+        Value::Sym(s) => Ok(s.force_scalar(&crate::input_rt::current())),
         other => Err(NoiseError::type_mismatch(
             format!("expected a number, got {}", other.type_name()),
             span,

--- a/crates/noise-core/src/eval/eval_arms.rs
+++ b/crates/noise-core/src/eval/eval_arms.rs
@@ -233,6 +233,24 @@ impl Engine {
         if is_dist(&iv) {
             return self.gather(&xs, iv, arr.span, idx.span);
         }
+        // A deterministic *array* of indices selects into a new array — `xs[0..r]` is the slice
+        // of the first `r` elements (ranges are arrays), and any index list works: `xs[[2, 0, 0]]`
+        // reorders/repeats. Each index resolves under the scalar rules (constant non-negative
+        // integer, in bounds); an array of *random* indices is rejected element-wise.
+        if let Value::Array(indices) = &iv {
+            let mut out = Vec::with_capacity(indices.len());
+            for ix in indices.iter() {
+                let i = self.array_index(ix, idx.span)?;
+                if i >= xs.len() {
+                    return Err(NoiseError::runtime(
+                        format!("array index {i} out of bounds (len {})", xs.len()),
+                        idx.span,
+                    ));
+                }
+                out.push(xs[i].clone());
+            }
+            return Ok(Value::Array(out.into()));
+        }
         let i = self.array_index(&iv, idx.span)?;
         if i >= xs.len() {
             return Err(NoiseError::runtime(

--- a/crates/noise-core/src/flint.rs
+++ b/crates/noise-core/src/flint.rs
@@ -614,7 +614,7 @@ mod tests {
         assert_eq!(rows[0]["st"], 0.5);
         assert_eq!(rows[3]["st"], 3.5);
         assert_eq!(rows[0]["share"], 0.1); // 100 of 1000 draws
-        // The text card carries every number the bars encode.
+                                           // The text card carries every number the bars encode.
         assert!(
             p.text.contains("n=1000") && p.text.contains("mean=2") && p.text.contains("q95=3.5"),
             "{}",

--- a/crates/noise-core/src/flint.rs
+++ b/crates/noise-core/src/flint.rs
@@ -297,19 +297,22 @@ fn dist1_chart(label: &str, d: &Dist1) -> Option<J> {
     if bins.is_empty() || !lo.is_finite() || !hi.is_finite() {
         return None;
     }
-    let value = field(label, &["count"]);
+    // Bars carry each bin's SHARE of the draws, not its raw count: a count axis leaks the sample
+    // budget (an implementation detail), while a 0–1 share reads the same at any budget.
+    let value = field(label, &["share"]);
+    let total = bins.iter().sum::<u64>().max(1) as f64;
     let rows = d
         .hist
         .midpoints(false)
         .into_iter()
         .zip(bins)
-        .map(|(mid, &count)| json!({ &value: mid, "count": count }))
+        .map(|(mid, &count)| json!({ &value: mid, "share": count as f64 / total }))
         .collect();
     Some(chart(
         rows,
-        json!({ &value: "Number", "count": "Count" }),
+        json!({ &value: "Number", "share": percentage() }),
         "Bar Chart",
-        json!({ "x": &value, "y": "count" }),
+        json!({ "x": &value, "y": "share" }),
         J::Null,
         CANVAS_W,
         CANVAS_H,
@@ -602,13 +605,15 @@ mod tests {
         assert_well_formed(&p.charts[0]);
         let c = &p.charts[0];
         assert_eq!(c["chart_spec"]["chartType"], "Bar Chart");
-        assert_eq!(c["semantic_types"]["count"], "Count");
+        // Bars encode each bin's share of the draws (0–1), not raw counts — a count axis would
+        // leak the sample budget.
+        assert_eq!(c["semantic_types"]["share"]["semanticType"], "Percentage");
         // 4 bins over [0, 4] ⇒ midpoints 0.5, 1.5, 2.5, 3.5 — never the bin edges.
         let rows = c["data"]["values"].as_array().unwrap();
         assert_eq!(rows.len(), 4);
         assert_eq!(rows[0]["st"], 0.5);
         assert_eq!(rows[3]["st"], 3.5);
-        assert_eq!(rows[0]["count"], 100);
+        assert_eq!(rows[0]["share"], 0.1); // 100 of 1000 draws
         // The text card carries every number the bars encode.
         assert!(
             p.text.contains("n=1000") && p.text.contains("mean=2") && p.text.contains("q95=3.5"),
@@ -863,11 +868,11 @@ mod tests {
             json!({ "x": "x", "y": "x_" })
         );
 
-        // A variable literally named `count` must not overwrite the histogram's count column.
-        let p = to_flint(&summary(View::Hist, "count", Payload::One(dist1(false))));
+        // A variable literally named `share` must not overwrite the histogram's share column.
+        let p = to_flint(&summary(View::Hist, "share", Payload::One(dist1(false))));
         assert_eq!(
             p.charts[0]["chart_spec"]["encodings"],
-            json!({ "x": "count_", "y": "count" })
+            json!({ "x": "share_", "y": "share" })
         );
         assert_well_formed(&p.charts[0]);
     }

--- a/crates/noise-core/src/num.rs
+++ b/crates/noise-core/src/num.rs
@@ -117,6 +117,23 @@ pub fn quantile_sorted(sorted: &[f64], q: f64) -> f64 {
     sorted[lo] + (sorted[hi] - sorted[lo]) * (pos - lo as f64)
 }
 
+/// Standard error of the sample `q`-quantile of a **sorted, non-empty** sample, density-free: the
+/// rank of the true quantile among `n` draws is Binomial(n, q), sd `sqrt(n·q·(1−q))`, so the
+/// half-width between the order statistics one rank-sd either side of the center is a ±1σ band for
+/// the quantile — no density estimate needed. Degenerate cases collapse to 0 ("exact"): `q` at the
+/// ends (the min/max draw is exactly itself) and plateaus of a discrete sample.
+pub fn quantile_se_sorted(sorted: &[f64], q: f64) -> f64 {
+    let n = sorted.len();
+    if n < 2 {
+        return 0.0;
+    }
+    let rank_sd = (n as f64 * q * (1.0 - q)).sqrt();
+    let center = q * (n - 1) as f64;
+    let lo = (center - rank_sd).floor().max(0.0) as usize;
+    let hi = ((center + rank_sd).ceil() as usize).min(n - 1);
+    (sorted[hi] - sorted[lo]) / 2.0
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/noise-core/tests/collections.rs
+++ b/crates/noise-core/tests/collections.rs
@@ -21,6 +21,28 @@ fn array_literals_index_and_len() {
 }
 
 #[test]
+fn array_slicing_with_index_arrays() {
+    // A deterministic index *array* selects into a new array. `a..b` is already an array, so
+    // `xs[0..r]` is the take-the-first-r slice; any index list reorders/repeats.
+    assert_eq!(display_of("[10, 20, 30, 40][1..3]"), "[20, 30]");
+    assert_eq!(display_of("[10, 20, 30][[2, 0, 0]]"), "[30, 10, 10]");
+    assert_eq!(display_of("[1, 2, 3][0..0]"), "[]"); // empty range → empty slice
+    // Slicing a vector of random draws: max over the first r elements equals the running max
+    // at r-1 (every lane), and E[max of 3 uniforms] = 3/4.
+    assert_eq!(
+        num("xs ~[5] unif(0, 1); P(max(xs[0..3]) == cummax(xs)[2])"),
+        1.0
+    );
+    assert!((num("xs ~[5] unif(0, 1); E(max(xs[0..3]))") - 0.75).abs() < 0.01);
+    // Matrix rows slice like any elements: M[1..3] is rows 1 and 2.
+    assert_eq!(display_of("[[1, 2], [3, 4], [5, 6]][1..2]"), "[[3, 4]]");
+    // Errors: an element out of bounds, and a random index inside the array (a per-lane
+    // multi-gather is not a thing — the scalar-index rules apply element-wise).
+    assert!(run("[1, 2, 3][1..5]").is_err());
+    assert!(run("i ~ unif_int(0, 1); [1, 2, 3][[i, 0]]").is_err());
+}
+
+#[test]
 fn array_index_errors() {
     assert!(run("[1, 2, 3][5]").is_err()); // out of bounds
     assert!(run("[1, 2, 3][1.5]").is_err()); // non-integer index

--- a/crates/noise-core/tests/collections.rs
+++ b/crates/noise-core/tests/collections.rs
@@ -27,8 +27,8 @@ fn array_slicing_with_index_arrays() {
     assert_eq!(display_of("[10, 20, 30, 40][1..3]"), "[20, 30]");
     assert_eq!(display_of("[10, 20, 30][[2, 0, 0]]"), "[30, 10, 10]");
     assert_eq!(display_of("[1, 2, 3][0..0]"), "[]"); // empty range → empty slice
-    // Slicing a vector of random draws: max over the first r elements equals the running max
-    // at r-1 (every lane), and E[max of 3 uniforms] = 3/4.
+                                                     // Slicing a vector of random draws: max over the first r elements equals the running max
+                                                     // at r-1 (every lane), and E[max of 3 uniforms] = 3/4.
     assert_eq!(
         num("xs ~[5] unif(0, 1); P(max(xs[0..3]) == cummax(xs)[2])"),
         1.0

--- a/crates/noise-core/tests/document.rs
+++ b/crates/noise-core/tests/document.rs
@@ -24,6 +24,18 @@ fn input_resolves_to_its_default_value() {
 }
 
 #[test]
+fn input_folds_in_builtin_numeric_arguments() {
+    // A symbolic input handed to an eager numeric builtin (math::round, a sample count, …) folds
+    // to its current value — the structural materialization — instead of a type error. The
+    // regression: `math::round(2 * slider - 1, 2)` used to fail with "expected a number, got
+    // number".
+    assert_eq!(
+        num("p = input::real(min: 0.5, max: 1, default: 0.6); math::round(2 * p - 1, 2)"),
+        0.2
+    );
+}
+
+#[test]
 fn input_override_is_clamped_and_snapped() {
     let mut e = Engine::new();
     e.set_input_overrides(vec![(

--- a/crates/noise-core/tests/sampling.rs
+++ b/crates/noise-core/tests/sampling.rs
@@ -495,10 +495,14 @@ fn quantile_domain_and_arity_are_checked() {
 #[test]
 fn quantile_is_always_active_like_other_builtins() {
     // `Q` lives in the always-on `builtin` module — no `use vec/math` needed (mirrors P/E/Var);
-    // only `rand` is needed for the distribution constructor.
+    // only `rand` is needed for the distribution constructor. Like P/E/Var it returns an
+    // estimate, with a density-free order-statistic standard error.
     match run_raw("use rand; X ~ unif(0, 1); Q(X, 0.5)").unwrap() {
-        Value::Num(m) => assert!((m - 0.5).abs() < 5e-3, "median = {m}"),
-        other => panic!("expected a number, got {other:?}"),
+        Value::Est { val, se } => {
+            assert!((val - 0.5).abs() < 5e-3, "median = {val}");
+            assert!(se > 0.0 && se < 5e-3, "median se = {se}");
+        }
+        other => panic!("expected an estimate, got {other:?}"),
     }
 }
 

--- a/examples/advantage.noise
+++ b/examples/advantage.noise
@@ -8,13 +8,21 @@ abstract: >
 tags: [games, lifted if]
 ---
 
-A ~ rand::unif_int(1, 20);
-B ~ rand::unif_int(1, 20);
-higher = if A > B { A } else { B };
-p = P(higher >= 15);
+```md
+**The roll.** Two d20s, keep the higher. Drag the target number your character
+has to hit.
+```
+target = input::int(min: 2, max: 20, step: 1, default: 15)
+A ~ rand::unif_int(1, 20)
+B ~ rand::unif_int(1, 20)
+higher = if A > B { A } else { B }
+
+p_advantage = P(higher >= target)
+p_straight  = P(A >= target)
 
 ```md
-The chance an advantage roll lands **≥ 15** is **${p * 100}%**.
+Hitting **${target}+** with advantage: **${p_advantage * 100}%** — against
+${p_straight * 100}% on a straight roll.
 ```
 
 // Advantage leans the d20 toward the high end: big numbers get the tallest bars.

--- a/examples/am_vs_fm.noise
+++ b/examples/am_vs_fm.noise
@@ -7,50 +7,60 @@ abstract: >
   which noise hits head-on, and FM in its angle, which a wider swing can defend.
 tags: [signals, dsp, complex]
 ---
-use math;
-use vec;
+use math
+use vec
 
-engine::set_resolution(64);       // how many points per waveform
-
-am_modulate(msg)              = 1 + msg;               // message in the LENGTH (the angle stays 0)
-fm_modulate(msg, swing)       = exp(i * swing * msg);  // message in the ANGLE
-am_demodulate(carrier)        = abs(carrier) - 1;      // read the arrow's LENGTH, drop the carrier
-fm_demodulate(carrier, swing) = arg(carrier) / swing;  // read the arrow's ANGLE, undo the swing
-
-// Drag: a wider swing spreads FM across more band, so it shrugs off static better. Kept <= 5 so the
-// angle never wraps past +/- 90 degrees (msg peaks at 0.3, and 5 * 0.3 < pi/2).
-fm_swing       = input::real(min: 1, max: 5, step: 0.5, default: 3);
-// Drag: crank the static up and watch AM fall apart faster than FM for the exact same storm.
-noise_strength = input::real(min: 0, max: 1, step: 0.05, default: 0.4);
-
-// A gentle 3-cycle tone, kept small so the FM angle never wraps past +/- 90 degrees.
-msg = 0.3 * signal::sine(3);
-
-// ONE draw of complex static. Every mention of `static` below is this same draw, so AM and FM
-// face the exact same storm — a perfectly fair fight.
-static ~ signal::noise_white_complex(noise_strength);
-
-recovered_am = am_demodulate(am_modulate(msg)           + static);
-recovered_fm = fm_demodulate(fm_modulate(msg, fm_swing) + static, fm_swing);
-
-// How mangled did each message come back? mse averages over the waveform's points; E averages
-// that over many realizations of the static.
-am_err = E(mse(recovered_am, msg));
-fm_err = E(mse(recovered_fm, msg));
+engine::set_resolution(64)   // points per waveform
 
 ```md
-AM recovered-message error (MSE) = **${am_err}**
-FM recovered-message error (MSE) = **${fm_err}**
+**Two ways to hide a message.** Think of the radio wave as a spinning arrow.
+AM stretches the arrow — the message rides in its *length*. FM twists it — the
+message rides in its *angle*. Each scheme decodes by reading back the part the
+noise didn't own.
 ```
+am_modulate(msg)              = 1 + msg
+fm_modulate(msg, swing)       = exp(i * swing * msg)
+am_demodulate(carrier)        = abs(carrier) - 1
+fm_demodulate(carrier, swing) = arg(carrier) / swing
 
-// In the small-signal limit the advantage approaches swing^2; the simulation lands a bit under
-// that ideal because at finite noise the angle reading degrades on the wider swings.
 ```md
-FM is **${am_err / fm_err}**x cleaner for the same static (ideal: swing^2 = **${fm_swing ^ 2}**)
+**The knobs.** A wider swing spreads FM across more band, buying it armor
+against static. And crank the static itself — the same storm hits both
+schemes.
+```
+// Swing stays <= 5 so the angle never wraps: the tone peaks at 0.3, and 5 * 0.3 < pi/2.
+fm_swing       = input::real(min: 1, max: 5, step: 0.5, default: 3)
+noise_strength = input::real(min: 0, max: 1, step: 0.05, default: 0.4)
+
+```md
+**A fair fight.** A gentle 3-cycle tone, and *one* draw of complex static —
+every mention of `static` is the same draw, so AM and FM face the exact same
+storm.
+```
+msg    = 0.3 * signal::sine(3)
+static ~ signal::noise_white_complex(noise_strength)
+
+recovered_am = am_demodulate(am_modulate(msg)           + static)
+recovered_fm = fm_demodulate(fm_modulate(msg, fm_swing) + static, fm_swing)
+
+am_err    = E(mse(recovered_am, msg))
+fm_err    = E(mse(recovered_fm, msg))
+advantage = am_err / fm_err
+```md
+**The verdict.** AM's recovered message comes back with mean-squared error
+**${am_err}**, FM's with **${fm_err}** — through the very same static. The
+advantage runs a little under the small-signal ideal, because at finite noise
+the angle reading frays on the widest swings:
+```
+```latex
+\frac{\text{AM error}}{\text{FM error}} \approx ${advantage}
+\qquad \left(\text{ideal: } \text{swing}^2 = ${fm_swing ^ 2}\right)
 ```
 
-// The original tone, then what each scheme drags back out of the static: FM's recovered wave
-// hugs the message; AM's is visibly rattled by the same noise.
-plot::line(msg);
-plot::line(recovered_am);
+```md
+**See it.** The original tone, then what each scheme drags back out of the
+static: FM's wave hugs the message, AM's is visibly rattled.
+```
+plot::line(msg)
+plot::line(recovered_am)
 plot::line(recovered_fm)

--- a/examples/barrier_option.noise
+++ b/examples/barrier_option.noise
@@ -8,53 +8,71 @@ abstract: >
   we get by just simulating the year, week by week, a few hundred thousand times?
 tags: [finance, monte carlo]
 ---
-use math;   // exp, sqrt
-use vec;    // cumsum, cummax, any, min
+use math   // exp, sqrt
+use vec    // cumsum, cummax, any, min
 
-// --- The contract ---
-s0      = 100;
-strike  = 100;    // at expiry you are paid max(S_T - strike, 0)
+```md
+**The contract.** The stock starts at 100 and the call is struck at 100 — at
+year's end it pays whatever the stock finishes above the strike. Then the
+trapdoor: drag the barrier up toward the stock price and knock-outs multiply,
+making the option cheaper; drop it and the price climbs back to the vanilla
+value.
+```
+start_price = 100
+strike      = 100
+barrier     = input::real(min: 50, max: 95, step: 5, default: 80)
 
-// Slide the trapdoor's height: raise it toward 100 and the option gets knocked out more (cheaper);
-// drop it toward 0 and knock-outs vanish, so the price climbs back up to the vanilla 10.4506.
-barrier = input::real(min: 50, max: 95, step: 5, default: 80);  // void if the stock EVER trades below this
+```md
+**A year of prices, week by week.** Draw 52 weekly shocks and compound them.
+Summing log-returns keeps the simulation *exact* geometric Brownian motion —
+no discretization error blurring the price.
+```
+rate       = 0.05
+volatility = 0.2
+weeks      = 52
+dt         = 1 / weeks
+shocks ~[weeks] rand::normal(0, 1)
+logrets = (rate - volatility^2 / 2) * dt + volatility * sqrt(dt) * shocks
+path    = start_price * exp(cumsum(logrets))
 
-r       = 0.05;
-sigma   = 0.2;    // volatility: a ~20% swing in a typical year
-t       = 1;
+```md
+**The two legs.** The same simulated paths price both contracts: the plain
+call, and the knock-out — identical payoff, voided if the stock *ever* trades
+below the barrier.
+```
+final_price = path[weeks - 1]
+vanilla  = if final_price > strike { final_price - strike } else { 0 }
+knocked  = any(path < barrier)
+knockout = if knocked { 0 } else { vanilla }
 
-// --- One simulated year, one week at a time ---
-n  = 52;
-dt = t / n;
-zs ~[n] rand::normal(0, 1);
-logrets = (r - sigma^2 / 2) * dt + sigma * sqrt(dt) * zs;
-
-// Building the price in log-space makes this EXACT geometric Brownian motion: summing the weekly
-// log-returns with cumsum has zero discretization error, unlike stepping the price directly.
-path    = s0 * exp(cumsum(logrets));
-
-// --- The two legs ---
-s_final = path[n - 1];
-vanilla = if s_final > strike { s_final - strike } else { 0 };  // plain call payoff
-knocked = any(path < barrier);                                  // did we ever touch the trapdoor?
-knockout = if knocked { 0 } else { vanilla };                   // same payoff, void if touched
-
-// --- Prices are discounted expected payoffs ---
-discount = exp(-r * t);
-
+```md
+**The prices.** A price is the discounted expected payoff. The vanilla leg has
+a closed form to check against — Black–Scholes says 10.4506 — and the trapdoor
+shows up as pure discount:
+```
+discount       = exp(-rate)
+price_vanilla  = E(discount * vanilla)
+price_knockout = E(discount * knockout)
+p_knocked      = P(knocked)
 ```latex
-\text{vanilla call} = ${E(discount * vanilla)} \qquad (\text{Black-Scholes says } 10.4506)
-\text{knock-out call} = ${E(discount * knockout)} \qquad (\text{cheaper: the trapdoor eats some payoffs})
-P(\text{knocked out}) = ${P(knocked) * 100}\%
+\text{vanilla} \approx ${price_vanilla}, \qquad
+\text{knock-out} \approx ${price_knockout}, \qquad
+P(\text{knocked out}) \approx ${p_knocked * 100}\%
 ```
 
-// Bonus one-liner: cummax(path) is the running peak, so this is the worst peak-to-trough
-// drawdown the stock suffers along the way — a risk number for free from the same paths.
-drawdown = min(path / cummax(path)) - 1;
+```md
+**A free risk number.** The running peak is one `cummax` away, so the worst
+peak-to-trough drawdown of the year falls out of the same paths:
+```
+drawdown         = min(path / cummax(path)) - 1
+typical_drawdown = E(drawdown)
 
-```latex
-\text{typical worst drawdown along the way} = ${E(drawdown)}
+```md
+Typical worst drawdown along the way: **${typical_drawdown * 100}%**
 ```
 
-// The cone of possible price paths: week-by-week 5/25/50/75/95% bands of the simulated year.
+```md
+**The cone.** Week-by-week 5–95% bands of the simulated year — the barrier is
+a floor some of these paths quietly fall through.
+```
 plot::fan(path)

--- a/examples/beta_bernoulli.noise
+++ b/examples/beta_bernoulli.noise
@@ -7,33 +7,50 @@ abstract: >
   posterior. The data pulls your best guess to about 0.67, notably shy of the raw 7-in-10.
 tags: [bayesian, inference]
 ---
-use vec;
+use vec
 
-bias  ~ rand::unif(0, 1);            // prior: the bias could be anything in [0, 1], equally likely
-flips ~[10] rand::bernoulli(bias);  // a RANDOM parameter feeding bernoulli — 10 flips of THIS coin
-next  ~ rand::bernoulli(bias);      // an 11th flip from the same coin (for the prediction below)
+```md
+**Start ignorant.** The bias could be anything in [0, 1], equally likely.
+The evidence is 10 flips of *that* coin — a random parameter feeding a
+Bernoulli — plus an 11th flip saved for a prediction later.
+```
+bias  ~ rand::unif(0, 1)
+flips ~[10] rand::bernoulli(bias)
+next  ~ rand::bernoulli(bias)
+heads = count(flips)
+prior_mean = E(bias)
 
-heads = count(flips);
-
-// Before any data, the bias averages 1/2 — that is just the flat prior showing through.
-```latex
-E[\text{bias}] = ${E(bias)} \quad (0.5)
+```md
+Before any data, the belief averages **${prior_mean}** — the flat prior
+showing through.
 ```
 
-// Conditioning is the whole trick: `| heads == 7` keeps only the worlds that produced our data,
-// and the posterior mean of a flat prior after h of n heads is (h+1)/(n+2) = 8/12 = 0.6667.
+```md
+**Let the data reshape it.** Conditioning on `heads == 7` keeps only the
+worlds that produced our data. For a flat prior the answer has a closed form
+to check against:
+```
+posterior      = bias | heads == 7
+posterior_mean = E(posterior)
+low90          = Q(posterior, 0.05)
+high90         = Q(posterior, 0.95)
 ```latex
-E[\text{bias} \mid 7/10] = ${E(bias | heads == 7)} \quad (0.6667)
-\text{90\% interval} = [\, ${Q(bias | heads == 7, 0.05)},\ ${Q(bias | heads == 7, 0.95)} \,]
+E[\text{bias} \mid h \text{ of } n] = \frac{h+1}{n+2} = \frac{8}{12} \approx ${posterior_mean},
+\qquad 90\%\ \text{interval:}\ [\,${low90},\ ${high90}\,]
 ```
 
-// The posterior predictive lands on the same 8/12: your belief about the coin IS your bet on it.
+```md
+**Your belief is your bet.** The chance the 11th flip lands heads is the same
+8/12 — the posterior predictive:
+```
+p_next_heads = P(next | heads == 7)
 ```latex
-P(\text{next flip heads} \mid 7/10) = ${P(next | heads == 7)} \quad (0.6667)
+P(\text{next flip heads} \mid 7/10) \approx ${p_next_heads}
 ```
 
-// Prior vs posterior, side by side: a flat slab of equal possibilities...
-plot::histogram(bias);
-
-// ...collapsing into a clear peak near 0.7 once the 7-of-10 evidence lands.
-plot::histogram(bias | heads == 7)
+```md
+**Watch the collapse.** The prior is a flat slab of equal possibilities; the
+posterior is what 7-of-10 leaves of it — a clear peak near 0.7.
+```
+plot::histogram(bias)
+plot::histogram(posterior)

--- a/examples/birthday.noise
+++ b/examples/birthday.noise
@@ -7,16 +7,24 @@ abstract: >
 tags: [collections, classic]
 ---
 
-n = input::int(min: 2, max: 100, step: 1, default: 23);
-
-share ~[n] rand::unif_int(1, 365);
-matched = vec::has_duplicates(share);
+```md
+**The room.** Everyone gets a uniformly random birthday, and the question is
+whether *any* two collide. Drag the head count.
+```
+people = input::int(min: 2, max: 100, step: 1, default: 23)
+birthdays ~[people] rand::unif_int(1, 365)
+matched = vec::has_duplicates(birthdays)
+p_match = P(matched)
 
 ```md
-With ${n} people, the chance that two share a birthday is **${P(matched) * 100}%**.
+With ${people} people, the chance that two share a birthday is
+**${p_match * 100}%**.
 ```
 
-// The exact odds against group size: a steep climb that clears 50% at just 23 people.
-chance(k) = { miss = 1.0; for i in 1..k { miss = miss * (365 - i) / 365 }; 1 - miss };
-odds_by_size = [for g in 1..61 { chance(g) }];
+```md
+**The exact curve.** The collision chance has a closed form — multiply out
+the survival odds person by person. Here it is for every room size up to 60:
+a climb far steeper than intuition expects, clearing 50% at just 23.
+```
+odds_by_size = [for k in 1..61 { miss = 1; for i in 1..k { miss = miss * (365 - i) / 365 }; 1 - miss }]
 plot::line(odds_by_size)

--- a/examples/bootstrap.noise
+++ b/examples/bootstrap.noise
@@ -9,39 +9,58 @@ abstract: >
 tags: [statistics, resampling]
 ---
 
-use vec;
+use math   // round
+use vec
 
-// The data: 24 daily returns (0.012 = +1.2%). Days 11-14 are a panic streak around the -4%
-// crash — real markets have bad WEEKS, not just isolated bad days, and that will matter below.
+```md
+**The history.** 24 daily returns (0.012 = +1.2%). Days 11–14 are a panic
+streak around the −4% crash — real markets have bad *weeks*, not just isolated
+bad days, and that will matter below.
+```
 rets = [ 0.004, -0.006,  0.012,  0.003, -0.002,
          0.007,  0.001, -0.005,  0.008,  0.002,
         -0.012, -0.040, -0.018, -0.009,  0.011,
          0.006, -0.003,  0.009, -0.001,  0.013,
-        -0.007,  0.002,  0.010, -0.004 ];
-
-// Tomorrow is a uniformly-random day pulled straight from history (the iid bootstrap).
-tomorrow ~ rand::empirical(rets);
+        -0.007,  0.002,  0.010, -0.004 ]
 
 ```md
-E(tomorrow) = **${E(tomorrow)}** (sample mean: ${mean(rets)})
-1-day VaR (Q05) = **${Q(tomorrow, 0.05)}** — straight from history, crash included
-P(another -4% day) = **${P(tomorrow <= -0.04) * 100}%** (= 1/24, its share of history)
+**Tomorrow, resampled.** No curve fitting: tomorrow is a uniformly random day
+pulled straight from the history, so the crash keeps its exact 1-in-24 share
+of the future.
+```
+tomorrow      ~ rand::empirical(rets)
+mean_tomorrow = E(tomorrow)
+var_1day      = Q(tomorrow, 0.05)
+p_crash_again = P(tomorrow <= -0.04)
+
+```md
+E(tomorrow) = **${mean_tomorrow}** (sample mean: ${round(mean(rets), 4)})
+1-day VaR (Q05) = **${var_1day}** — straight from history, crash included
+P(another −4% day) = **${p_crash_again * 100}%** (= 1/24, its share of history)
 ```
 
-// No bell curve anywhere: a spike at each of the 24 real days, the lone -4% crash out in the tail.
-plot::histogram(tomorrow);
-
-// A WEEK is not 5 independent days: losses cluster. Shuffling days one at a time (iid) destroys
-// those streaks, so it understates weekly risk. The BLOCK bootstrap instead glues random
-// contiguous 5-day runs of history together, keeping each streak intact.
-iid_days ~[5] rand::empirical(rets);
-iid_week = sum(iid_days);
-
-week ~ rand::block_bootstrap(rets, 5);            // a full resampled series, in 5-day blocks
-hist_week = sum([for j in 0..5 { week[j] }]);      // its first block = one real 5-day run
+```md
+**No bell curve anywhere.** A spike at each of the 24 real days, the lone −4%
+crash out in the tail — exactly as fat as history says it is.
+```
+plot::histogram(tomorrow)
 
 ```md
-iid week VaR (Q05) = **${Q(iid_week, 0.05)}** — streaks shuffled away
-real week VaR (Q05) = **${Q(hist_week, 0.05)}** — the panic week stays glued together
-Blocks matter whenever returns are autocorrelated: same days, scarier (honest) tail.
+**A week is not five independent days.** Losses cluster. Resampling days one
+at a time shuffles the panic streak away; the *block* bootstrap instead glues
+random contiguous 5-day runs of history together, keeping each streak intact.
+```
+iid_days ~[5] rand::empirical(rets)
+iid_week = sum(iid_days)
+week ~ rand::block_bootstrap(rets, 5)
+streak_week = sum([for j in 0..5 { week[j] }])
+var_iid_week    = Q(iid_week, 0.05)
+var_streak_week = Q(streak_week, 0.05)
+
+```md
+iid week VaR (Q05) = **${var_iid_week}** — streaks shuffled away
+block week VaR (Q05) = **${var_streak_week}** — the panic week stays glued together
+
+Same 24 days, scarier (honest) tail: blocks matter whenever returns remember
+yesterday.
 ```

--- a/examples/buffon.noise
+++ b/examples/buffon.noise
@@ -7,21 +7,27 @@ abstract: >
   nothing but a needle and a tally. A 250-year-old Monte Carlo trick.
 tags: [monte carlo, geometry]
 ---
-use math;
+use math
 
-// When it lands, the needle's center falls a random distance from the nearest seam at a random tilt;
-// it crosses only when its half-length, leaning toward the line, reaches across that gap.
-d     ~ rand::unif(0, 0.5);      // center-to-nearest-line distance, spacing t = 1 so d lands in [0, 1/2]
-angle ~ rand::unif(0, pi / 2);   // tilt; by symmetry, [0, pi/2] already covers every case
-cross = d <= 0.5 * sin(angle);
+```md
+**One drop.** The needle's center lands a random distance from the nearest
+seam, at a random tilt (symmetry lets a quarter-turn cover every case). It
+crosses only when its half-length, leaning toward the seam, reaches across
+that gap.
+```
+distance ~ rand::unif(0, 0.5)
+tilt     ~ rand::unif(0, pi / 2)
+crosses  = distance <= 0.5 * sin(tilt)
 
-// Geometry pins the crossing chance to exactly 2/π, so inverting it turns a mere tally back into π.
-p = P(cross);
-
+```md
+**From tally to π.** Geometry pins the crossing chance at exactly 2/π — so
+inverting a mere tally of crossings measures π itself:
+```
+p_cross = P(crosses)
 ```latex
-P(\text{needle crosses a line}) = ${p} \approx \frac{2}{\pi} = ${2 / pi}
-\pi \approx \frac{2}{P(\text{cross})} \qquad (\text{true } \pi = ${pi})
+P(\text{cross}) = ${p_cross} \approx \frac{2}{\pi} = ${round(2 / pi, 4)},
+\qquad \pi \approx \frac{2}{P(\text{cross})} = ${2 / p_cross}
 ```
 
-// The π squeezed out of the needle, shown with only the error bar it has earned.
-plot::value(2 / p)
+// The π squeezed out of a needle, shown with only the error bar it has earned.
+plot::value(2 / p_cross)

--- a/examples/clt_normal.noise
+++ b/examples/clt_normal.noise
@@ -8,18 +8,27 @@ abstract: >
 tags: [continuous, clt]
 ---
 
-// Twelve is the magic count: a U(0,1) has variance 1/12, so twelve of them sum to variance exactly 1 — a ready-made standard normal.
-n     = 12;
-draws ~[n] rand::unif(0, 1);
-clt   = vec::sum(draws) - n / 2;
+```md
+**Twelve flat numbers.** A U(0,1) has variance exactly 1/12 — so the sum of
+twelve of them, recentered, has mean 0 and variance 1: a ready-made standard
+normal with no bell curve anywhere in the ingredients.
+```
+n = 12
+draws ~[n] rand::unif(0, 1)
+stacked = vec::sum(draws) - n / 2
+p_tail_stacked = P(stacked > 1)
+
+```md
+**The real thing.** Ask a native standard normal the same tail question:
+```
+Z ~ rand::normal(0, 1)
+p_tail_normal = P(Z > 1)
 ```latex
-P(Z > 1) \approx ${P(clt > 1) * 100}\% \qquad (\text{sum of } ${n} \text{ uniforms})
+P(\text{stacked} > 1) = ${p_tail_stacked * 100}\%, \qquad
+P(Z > 1) = ${p_tail_normal * 100}\%
 ```
 
-// The tail from stacked-up noise lands on the same ~16% as the real thing.
-Z ~ rand::normal(0, 1);
-```latex
-P(Z > 1) = ${P(Z > 1) * 100}\% \qquad (\text{native normal})
+```md
+**The shape.** Flat pieces, bell whole:
 ```
-
-plot::histogram(clt)
+plot::histogram(stacked)

--- a/examples/coin_streak.noise
+++ b/examples/coin_streak.noise
@@ -7,16 +7,23 @@ abstract: >
 tags: [independence, modeling]
 ---
 
-// How many coins we flip in a row — tune it and watch the all-heads chance halve each time.
-flip_count = input::int(min: 1, max: 20, step: 1, default: 3);
-
-flips  ~[flip_count] rand::bernoulli(0.5);
-streak = vec::all(flips);
-
 ```md
-P(all heads in a row) = **${P(streak) * 100}%**
+**The streak.** Every flip must land heads — one miss and it's over. Drag the
+length and watch each extra flip halve the odds.
+```
+flip_count = input::int(min: 1, max: 20, step: 1, default: 3)
+flips  ~[flip_count] rand::bernoulli(0.5)
+streak = vec::all(flips)
+p_streak = P(streak)
+
+```latex
+P(${flip_count} \text{ heads in a row}) = ${p_streak * 100}\%
+\qquad \left(2^{-k}\right)
 ```
 
-// The odds halve with every extra flip — the curve dives toward zero almost at once.
-odds_by_length = [for k in 1..11 { 0.5 ^ k }];
+```md
+**The dive.** Simulate every streak length from 1 to 10: the curve halves at
+each step and plunges toward zero almost at once.
+```
+odds_by_length = [for k in 1..11 { run ~[k] rand::bernoulli(0.5); P(vec::all(run), 50000) }]
 plot::line(odds_by_length)

--- a/examples/conditional_bayes.noise
+++ b/examples/conditional_bayes.noise
@@ -7,23 +7,39 @@ abstract: >
 tags: [probability, bayes]
 ---
 
-D ~ rand::unif_int(1, 6);
+```md
+**The hint.** A die roll, and one clue: it beat 3.
+```
+roll ~ rand::unif_int(1, 6)
+p_six_given_high = P(roll == 6 | roll > 3)
 
 ```md
-The chance a die known to have beaten 3 is actually a 6 is **${P(D == 6 | D > 3) * 100}%**.
+Given the hint, the chance it's actually a 6 is **${p_six_given_high * 100}%**
+— knowing it landed on 4, 5, or 6 leaves those three equally in the running.
 ```
 
-// A conditioned value is first-class: bind it once, then ask several questions of it.
-high = D | D > 3;                       // the roll, restricted to the worlds where D > 3
+```md
+**A conditioned value is first-class.** Bind "the roll, in the worlds where it
+beat 3" once, then ask it anything:
+```
+high = roll | roll > 3
+mean_high   = E(high)
+median_high = Q(high, 0.5)
 ```latex
-E[\text{roll} \mid \text{roll} > 3] = ${E(high)} \qquad(\text{mean of } 4,5,6 = 5)
-\mathrm{median}(\text{roll} \mid {>}\,3) = ${Q(high, 0.5)} \qquad(= 5)
+E[\text{roll} \mid {>}\,3] = ${mean_high}, \qquad
+\mathrm{median} = ${median_high} \qquad (\text{mean of } 4,5,6 = 5)
 ```
 
-// Same answer the long way — `P(A | C)` is exactly `P(A && C) / P(C)`, just less ceremony:
+```md
+**The same answer, the long way.** The bar is exactly the textbook ratio, with
+less ceremony:
+```
+p_ratio = P(roll == 6 && roll > 3) / P(roll > 3)
 ```latex
-P(D = 6 \mid D > 3) = \frac{P(D = 6 \cap D > 3)}{P(D > 3)} = ${P(D == 6 && D > 3) / P(D > 3)}
+\frac{P(\text{roll}=6 \,\cap\, \text{roll}>3)}{P(\text{roll}>3)} = ${p_ratio}
 ```
 
-// Once we know the roll beat 3, only 4, 5 and 6 are left — see them share the chances evenly.
+```md
+**Only three faces left.** 4, 5 and 6, sharing the chances evenly:
+```
 plot::histogram(high)

--- a/examples/dice.noise
+++ b/examples/dice.noise
@@ -8,11 +8,23 @@ abstract: >
 tags: [basics, discrete]
 ---
 
-Dice ~ rand::unif_int(1, 6);
-p = P(Dice == 4);
-
+```md
+**The die.** Six whole numbers, equally likely.
+```
+roll ~ rand::unif_int(1, 6)
+p_four = P(roll == 4)
 ```latex
-P(\text{rolling a } 4) = ${p * 100}\%
+P(\text{rolling a } 4) = ${p_four * 100}\%
 ```
 
-plot::histogram(Dice)
+```md
+**The trap.** Ask instead for a *continuous* value between 1 and 6 — a real
+number never lands exactly on a point, so the same question collapses to zero:
+```
+spot ~ rand::unif(1, 6)
+p_exactly_four = P(spot == 4)
+```latex
+P(\text{spot} = 4) = ${p_exactly_four}
+```
+
+plot::histogram(roll)

--- a/examples/dice_bet.noise
+++ b/examples/dice_bet.noise
@@ -7,12 +7,12 @@ abstract: >
 tags: [lifted if, risk]
 ---
 
-D ~ rand::unif_int(1, 6);
-payoff = if D == 6 { 10 } else { 0 - 2 };
-p = P(payoff > 0);
+roll ~ rand::unif_int(1, 6)
+payoff = if roll == 6 { 10 } else { -2 }
+p_ahead = P(payoff > 0)
 
 ```md
-The chance you come out ahead is **${p * 100}%**.
+The chance you come out ahead is **${p_ahead * 100}%**.
 ```
 
 // Two outcomes only: a tall -2 bar (you usually lose a bit) and a short +10 bar.

--- a/examples/dice_sum.noise
+++ b/examples/dice_sum.noise
@@ -8,16 +8,19 @@ abstract: >
 tags: [independence, collections]
 ---
 
-// Slide the number of dice: two make a lopsided triangle, but pile on more and the total rounds into a bell.
-num_dice = input::int(min: 1, max: 20, step: 1, default: 2);
+```md
+**The roll.** Slide the number of dice: two make a lopsided triangle of
+totals, but pile on more and the shape rounds into a bell.
+```
+num_dice = input::int(min: 1, max: 20, step: 1, default: 2)
 
-die   = rand::unif_int(1, 6);
-
-// Each ~ draw is a fresh, independent roll — die + die would be one roll doubled, not two dice.
-dice  ~[num_dice] die;
-total = vec::sum(dice);
+// Each ~ draw is a fresh, independent roll — `die + die` would be one roll doubled, not two dice.
+die   = rand::unif_int(1, 6)
+dice  ~[num_dice] die
+total = vec::sum(dice)
+p_seven = P(total == 7)
 ```latex
-P(\text{${num_dice} dice sum to } 7) = ${P(total == 7) * 100}\%
+P(\text{${num_dice} dice sum to } 7) = ${p_seven * 100}\%
 ```
 
 plot::histogram(total)

--- a/examples/dithering.noise
+++ b/examples/dithering.noise
@@ -8,39 +8,50 @@ abstract: >
 tags: [signals, dsp]
 ---
 
-use math;
-
-// A 1-bit quantizer reports only the SIGN (+1 / -1) of its input. Ask it about a fixed level v and
-// it's useless: it answers "+1" for any positive v, telling you nothing about HOW big v is.
-v = 0.3;
+use math
 
 ```md
-no dither: E[sign(v)] = **${E(sign(v))}** (stuck at +1 — says nothing about v = ${v})
+**A sensor with one bit.** It reports only the *sign* of its input. Ask it
+about a fixed positive level and every answer is identical — the average is
+pinned at +1, whether the level is 0.3 or 0.8.
 ```
-
-// Now add uniform dither in [-1, 1] BEFORE the comparator and average many comparisons. The noise
-// randomizes the threshold crossing so that, for |v| < 1, E[sign(v + u)] = v EXACTLY: the average
-// of the 1-bit answers reconstructs the analog level. One noisy bit, repeated, becomes a ruler.
-// Drag the dither amount: too little (< the level) and the comparator stays stuck; enough to span the
-// range and the average goes perfectly linear. At 1.0 the dither covers [-1, 1] and recovery is exact.
-dither = input::real(min: 0, max: 2, step: 0.1, default: 1);
-
-u ~ rand::unif(-dither, dither);
+level = 0.3
+stuck_average = E(sign(level))
 
 ```md
-dithered: E[sign(v + u)] = **${E(sign(v + u))}** (recovers v = ${v})
+Naked 1-bit average: **${stuck_average}** — says nothing about the level.
 ```
 
-// And it's not a fluke for one value — the response is LINEAR. Each level comes back on the nose.
 ```md
-linearity check (dithered average should equal the input):
-v = -0.5 -> **${E(sign(-0.5 + u))}**
-v =  0.0 -> **${E(sign( 0.0 + u))}**
-v =  0.8 -> **${E(sign( 0.8 + u))}**
+**Add noise, then ask.** Uniform dither randomizes the threshold crossing: as
+long as the dither spans the level, the average of many yes/no answers *is*
+the level. Drag it — too little and the sensor stays stuck; at 1 it covers the
+whole range and recovery is exact.
+```
+dither = input::real(min: 0, max: 2, step: 0.1, default: 1)
+u ~ rand::unif(-dither, dither)
+dithered_average = E(sign(level + u))
+```latex
+\mathbb{E}\left[\operatorname{sign}(v + u)\right] = v \approx ${dithered_average}
+\qquad (v = ${level})
 ```
 
-// Sweep the input from -1 to +1 and plot the dithered 1-bit average at each level: a clean straight
-// ramp, proof that the noisy comparator reconstructs the analog value linearly.
+```md
+**Not a fluke — it's linear.** Any level comes back on the nose:
+```
+recovered_low  = E(sign(-0.5 + u))
+recovered_zero = E(sign( 0.0 + u))
+recovered_high = E(sign( 0.8 + u))
+
+```md
+−0.5 → **${recovered_low}**, 0.0 → **${recovered_zero}**, 0.8 → **${recovered_high}**
+```
+
+```md
+**The whole ramp.** Sweep the input from −1 to +1: the dithered 1-bit average
+traces a straight line through every level. One noisy bit, repeated, becomes a
+ruler.
+```
 ramp = [sign(-1.0 + u), sign(-0.8 + u), sign(-0.6 + u), sign(-0.4 + u), sign(-0.2 + u),
-        sign( 0.0 + u), sign( 0.2 + u), sign( 0.4 + u), sign( 0.6 + u), sign( 0.8 + u), sign( 1.0 + u)];
+        sign( 0.0 + u), sign( 0.2 + u), sign( 0.4 + u), sign( 0.6 + u), sign( 0.8 + u), sign( 1.0 + u)]
 plot::line(ramp)

--- a/examples/exactly_two_heads.noise
+++ b/examples/exactly_two_heads.noise
@@ -8,12 +8,13 @@ abstract: >
 tags: [modeling, collections]
 ---
 
-coin  = rand::bernoulli(0.5);
-flips ~[3] coin;
-heads = vec::count(flips);
+coin  = rand::bernoulli(0.5)
+flips ~[3] coin
+heads = vec::count(flips)
+p_two = P(heads == 2)
 
 ```md
-P(exactly two heads of three) = **${P(heads == 2) * 100}%**
+P(exactly two heads of three) = **${p_two * 100}%**
 ```
 
 // The whole shape at a glance — the bar at two heads is the 3/8 we asked for.

--- a/examples/functions.noise
+++ b/examples/functions.noise
@@ -8,16 +8,28 @@ abstract: >
 tags: [functions, language]
 ---
 
-max(a, b) = if a > b { a } else { b };
-roll() ~ rand::unif_int(1, 6);
-
-A ~ rand::unif_int(1, 6);
-B ~ rand::unif_int(1, 6);
+```md
+**Two kinds of function.** `max` is a pure rule — same inputs, same answer,
+every time. `roll()` is declared with `~`, so every *call* is a fresh,
+independent draw.
+```
+max(a, b) = if a > b { a } else { b }
+roll() ~ rand::unif_int(1, 6)
 
 ```md
-P(higher of two d6 is a 6) = **${P(max(A, B) == 6) * 100}%**
-P(two independent rolls sum to 7) = **${P(roll() + roll() == 7) * 100}%**
+**Both in action.** The pure rule applied to two dice, and one die function
+called twice — genuinely two dice, which is why a 7 keeps its 1-in-6 odds.
+```
+A ~ rand::unif_int(1, 6)
+B ~ rand::unif_int(1, 6)
+higher = max(A, B)
+p_high_six    = P(higher == 6)
+p_lucky_seven = P(roll() + roll() == 7)
+
+```md
+P(higher of two d6 is a 6) = **${p_high_six * 100}%**
+P(two independent rolls sum to 7) = **${p_lucky_seven * 100}%**
 ```
 
-// The max of two dice leans high: a 6 is far likelier than a 1, since either die can supply it.
-plot::histogram(max(A, B))
+// The max of two dice leans high: either die can supply the 6.
+plot::histogram(higher)

--- a/examples/insurance.noise
+++ b/examples/insurance.noise
@@ -8,17 +8,20 @@ abstract: >
 tags: [risk, lifted if]
 ---
 
-// The two dials of the policy: the loss range, and the deductible the customer eats first.
-deductible = input::real(min: 0,   max: 1000, step: 50,  default: 200);
-max_loss   = input::real(min: 100, max: 5000, step: 100, default: 1000);
+```md
+**The two dials of the policy.** How bad a loss can get, and the first slice
+of it the customer eats before the insurer pays a cent.
+```
+deductible = input::real(min: 0,   max: 1000, step: 50,  default: 200)
+max_loss   = input::real(min: 100, max: 5000, step: 100, default: 1000)
 
-loss ~ rand::unif_int(0, max_loss);
-claim = if loss > deductible { loss - deductible } else { 0 };
-p = P(claim > 0);
+loss  ~ rand::unif_int(0, max_loss)
+claim = if loss > deductible { loss - deductible } else { 0 }
+p_pays = P(claim > 0)
 
 ```md
-The chance the insurer pays a claim is **${p * 100}%**.
+The chance the insurer pays a claim is **${p_pays * 100}%**.
 ```
 
-// A big spike at $0 (small losses below the deductible) then a flat spread of real payouts.
+// A big spike at $0 (losses below the deductible) then a flat spread of real payouts.
 plot::histogram(claim)

--- a/examples/irwin_hall.noise
+++ b/examples/irwin_hall.noise
@@ -8,13 +8,16 @@ abstract: >
 tags: [continuous, collections]
 ---
 
-// Slide n: one draw is flat, two make a triangle, a dozen round into a bell — the CLT in miniature.
-n = input::int(min: 1, max: 12, step: 1, default: 3);
-
-draws ~[n] rand::unif_int(0, 1);
-total = vec::sum(draws);
+```md
+**Stack them up.** Drag n: one uniform is flat, two make a triangle, and a
+dozen round into a bell — the central limit theorem in miniature.
+```
+n = input::int(min: 1, max: 12, step: 1, default: 3)
+draws ~[n] rand::unif(0, 1)
+total = vec::sum(draws)
+p_big = P(total > 2)
 ```latex
-P(\text{sum of } ${n} \text{ uniforms} > 2) = ${P(total > 2) * 100}\%
+P(\text{sum of } ${n} \text{ uniforms} > 2) = ${p_big * 100}\%
 ```
 
 plot::histogram(total)

--- a/examples/kelly.noise
+++ b/examples/kelly.noise
@@ -8,34 +8,37 @@ abstract: >
 tags: [betting, optimization]
 ---
 
-// Why maximize the LOG of growth, not the growth itself? Bankrolls MULTIPLY round to round,
-// so what actually compounds is the average log-return — and that peaks at f* = 2p - 1 = 0.2.
-log_growth(f) = {
-  win ~ rand::bernoulli(0.6);
-  g = if win { 1 + f } else { 1 - f };   // win: your stake f doubles; lose: it is gone
+```md
+**Why the logarithm?** Bankrolls *multiply* from round to round, so what
+compounds over a long run is the average log-return — not the average return.
+One round: stake a fraction f of the bankroll on a coin that wins with
+probability p; win and the stake doubles, lose and it's gone.
+```
+log_growth(f, p) = {
+  win ~ rand::bernoulli(p)
+  g = if win { 1 + f } else { 1 - f }
   E(math::log(g))
-};
-
-fractions = [for k in 0..11 { k / 20 }];
-growth    = [for f in fractions { log_growth(f) }];
+}
 
 ```md
-stake fraction f -> expected log-growth per round (bigger is better):
+**Your edge, your stake.** Drag both: how biased the coin is in your favor,
+and how much of the bankroll you put on each round.
 ```
-for k in 0..11 {
-  Print(`  f = ${fractions[k]} -> ${growth[k]}`)
-};
-
-// Your turn: drag your stake and watch the growth rate climb to the peak at 0.2, then go negative.
-my_stake = input::real(min: 0, max: 0.5, step: 0.05, default: 0.2);
-
-Print(`your stake f = ${my_stake} -> growth ${log_growth(my_stake)}`);
+win_odds = input::real(min: 0.5, max: 1, step: 0.05, default: 0.6)
+my_stake = input::real(min: 0, max: 1.0, step: 0.01, default: 0.2)
+my_growth   = log_growth(my_stake, win_odds)
+kelly_stake = 2 * win_odds - 1
+```latex
+E[\log g] = p \log(1+f) + (1-p)\log(1-f)
+\;\xrightarrow{\;f = ${my_stake}\;}\; ${my_growth}
+\qquad \text{peaked at } f^* = 2p - 1 = ${kelly_stake}
+```
 
 ```md
-The curve peaks at f* = 2p - 1 = 0.2 — the Kelly fraction — and goes NEGATIVE past ~0.4:
-overbetting a winning game loses money in the long run.
-(Analytic: E[log g] = p*log(1+f) + (1-p)*log(1-f); at f = 0.2 that's ~0.0201 per round.)
+**The whole curve.** Log-growth against stake, from f = 0 to 0.5: it crests at
+the Kelly fraction f* = ${kelly_stake} and turns negative once you push well
+past it — overbetting a *winning* game loses money in the long run.
 ```
-
-// The Kelly curve made visible: log-growth against stake, cresting at 0.2 then plunging below zero.
+fractions = [for k in 0..11 { k / 20 }]
+growth    = [for f in fractions { log_growth(f, win_odds) }]
 plot::line(growth)

--- a/examples/max_of_dice.noise
+++ b/examples/max_of_dice.noise
@@ -7,12 +7,13 @@ abstract: >
 tags: [lifted if]
 ---
 
-A ~ rand::unif_int(1, 6);
-B ~ rand::unif_int(1, 6);
-higher = if A > B { A } else { B };
-p = P(higher == 6);
+A ~ rand::unif_int(1, 6)
+B ~ rand::unif_int(1, 6)
+higher = if A > B { A } else { B }
+p_six  = P(higher == 6)
+
 ```md
-The chance the higher of 2d6 is a 6 is **${p * 100}%**.
+The chance the higher of 2d6 is a 6 is **${p_six * 100}%**.
 ```
 
 // Keeping the bigger die skews things high: 6 is by far the most common result.

--- a/examples/monty_hall.noise
+++ b/examples/monty_hall.noise
@@ -8,16 +8,23 @@ abstract: >
 tags: [classic, modeling]
 ---
 
-// Slide the doors: with 3, switching wins 2/3; crank it to 100 and you win 99 times out of 100.
-doors = input::int(min: 3, max: 100, step: 1, default: 3);
+```md
+**The setup.** A car behind one door, your blind first pick, and a host who
+then opens every other losing door. Crank the door count — at 100 doors the
+answer stops feeling like a coin toss.
+```
+doors = input::int(min: 3, max: 100, step: 1, default: 3)
+car  ~ rand::unif_int(1, doors)
+pick ~ rand::unif_int(1, doors)
 
-car  ~ rand::unif_int(1, doors);
-pick ~ rand::unif_int(1, doors);
+```md
+**The whole argument in one line.** After the host clears the field, switching
+wins in exactly the worlds where your blind first guess had missed the car.
+```
+switching_wins = P(pick != car)
+advice = if switching_wins > 0.5 { "Switch!" } else { "Stay." }
 
-// Switching wins in exactly the worlds where your first guess missed the car.
-p = P(pick != car);
-if p > 0.5 {
-  Print(`Switch! You win ${p * 100}% of the time.`)
-} else {
-  Print(`Stay. Switching only wins ${p * 100}% of the time.`)
-}
+```md
+**${advice}** With ${doors} doors, switching wins **${switching_wins * 100}%**
+of the time — staying wins only ${(1 - switching_wins) * 100}%.
+```

--- a/examples/noise_colors.noise
+++ b/examples/noise_colors.noise
@@ -7,46 +7,59 @@ abstract: >
   neurons to music? Count how alike neighboring samples are, and the colors sort themselves out.
 tags: [signals, dsp]
 ---
-use math;     // round
+use math     // round, exp
 
-n = 256;   // every color drawn at the same resolution
-
-// Lag-1 autocorrelation of a noise vector, averaged over many realizations. Built from the raw
-// spatial sums so it's E[<x_k x_{k+1}>] / E[<x_k^2>] — a clean ratio of means.
-// Each realization is already a 256-term sum (a huge amount of work per draw), so a few
-// thousand realizations pin the ratio to the 3 decimals we print — say so with a per-call
-// count instead of letting the default budget draw a million of these monsters.
-pair_sum(x) = { acc = 0; for i in 0..Len(x)-1 { acc = acc + x[i] * x[i+1] }; acc };
-sq_sum(x)   = { acc = 0; for i in 0..Len(x)-1 { acc = acc + x[i] * x[i]   }; acc };
-neighbor_corr(x) = E(pair_sum(x), 15000) / E(sq_sum(x), 15000);
-
-white ~[n] signal::noise_white(1);
-pink  ~[n] signal::noise_pink(1);
-brown ~[n] signal::noise_brown(1);
-
-// The spectrum reddens, the neighbor correlation climbs toward 1.
 ```md
-white (flat 1/f^0): **${round(neighbor_corr(white), 3)}** jagged hiss
-pink (~1/f): **${round(neighbor_corr(pink),  3)}**
-brown (1/f^2): **${round(neighbor_corr(brown), 3)}** smooth wander
+**The yardstick.** How alike is each sample to its neighbor? Take the ratio of
+"sample times next sample" to "sample squared", averaged over thousands of
+realizations — the lag-1 autocorrelation. It reads 0 for pure hiss and climbs
+toward 1 as the noise smooths out.
+```
+// Each realization is already a 256-term sum, so 15k draws pin 3 decimals — cap the budget per call.
+pair_sum(x) = { acc = 0; for i in 0..Len(x)-1 { acc = acc + x[i] * x[i+1] }; acc }
+sq_sum(x)   = { acc = 0; for i in 0..Len(x)-1 { acc = acc + x[i] * x[i]   }; acc }
+neighbor_corr(x) = E(pair_sum(x), 15000) / E(sq_sum(x), 15000)
+
+```md
+**Three colors, one ruler.** As the spectrum reddens from white through pink
+to brown, the neighbor memory climbs toward 1.
+```
+n = 256
+white ~[n] signal::noise_white(1)
+pink  ~[n] signal::noise_pink(1)
+brown ~[n] signal::noise_brown(1)
+white_memory = neighbor_corr(white)
+pink_memory  = neighbor_corr(pink)
+brown_memory = neighbor_corr(brown)
+
+```md
+white (flat 1/f⁰): **${round(white_memory, 3)}** — jagged hiss
+pink (~1/f): **${round(pink_memory, 3)}**
+brown (1/f²): **${round(brown_memory, 3)}** — smooth wander
 ```
 
-// OU is the tunable one: correlation = exp(-1/tau), checkable in closed form.
-ou_short ~[n] signal::noise_ou(1, 4);
-ou_long  ~[n] signal::noise_ou(1, 32);
 ```md
-
-OU colored noise — neighbor corr should track exp(-1/tau):
-tau = 4 : **${round(neighbor_corr(ou_short), 3)}** vs exp(-1/4)  = 0.779
-tau = 32: **${round(neighbor_corr(ou_long),  3)}** vs exp(-1/32) = 0.969
+**The dial-a-color.** Ornstein–Uhlenbeck noise has a memory knob τ, and a
+closed form to check the ruler against:
+```
+ou_short ~[n] signal::noise_ou(1, 4)
+ou_long  ~[n] signal::noise_ou(1, 32)
+short_memory = neighbor_corr(ou_short)
+long_memory  = neighbor_corr(ou_long)
+```latex
+\rho_1 = e^{-1/\tau}: \qquad
+\tau = 4:\ ${round(short_memory, 3)} \ \left(e^{-1/4} = ${round(exp(-1 / 4), 3)}\right), \qquad
+\tau = 32:\ ${round(long_memory, 3)} \ \left(e^{-1/32} = ${round(exp(-1 / 32), 3)}\right)
 ```
 
-// See the color: white noise is a jagged hiss, brown noise is a smooth wandering walk.
-plot::line(white);
-plot::line(brown);
-// And the structure behind it: white has no neighbor memory, brown's samples stay correlated
-// for a long stretch.
-white_64 ~[64] signal::noise_white(1);
-brown_64 ~[64] signal::noise_brown(1);
-plot::corr(white_64);
+```md
+**See the color.** White noise is a jagged hiss; brown noise is a smooth
+wandering walk. The correlation matrices show the structure behind it: white
+has no neighbor memory at all, brown's samples stay linked for long stretches.
+```
+plot::line(white)
+plot::line(brown)
+white_64 ~[64] signal::noise_white(1)
+brown_64 ~[64] signal::noise_brown(1)
+plot::corr(white_64)
 plot::corr(brown_64)

--- a/examples/nyquist.noise
+++ b/examples/nyquist.noise
@@ -7,29 +7,37 @@ abstract: >
   and they separate again. The sampling theorem, something you can watch happen.
 tags: [signals, dsp]
 ---
-high = signal::cosine(7);   // a fast wave: 7 cycles per window
-low  = signal::cosine(3);   // a slow wave: 3 cycles per window  -- genuinely a different signal
-
-// Nyquist limit for the 7-cycle wave: you need > 2*7 = 14 samples per window.
-// Drag the sample count across 14: below it the fast wave aliases — at 10 its samples become
-// *identical* to the slow one's, so mse is 0 and the two are indistinguishable. Cross above 14 and
-// they pull apart. (7 folds to 10-7 = 3 exactly at 10, which is why that rate gives mse = 0.)
-samples = input::int(min: 4, max: 64, step: 1, default: 10);
 
 ```md
-undersampled (${samples} pts, Nyquist needs > 14): mse(fast, slow) = **${vec::mse(signal::sample(high, samples), signal::sample(low, samples))}**
+**Two genuinely different waves.** A fast one at 7 cycles per window, a slow
+one at 3.
+```
+fast = signal::cosine(7)
+slow = signal::cosine(3)
+
+```md
+**The snapshot rate.** Nyquist says the 7-cycle wave needs more than 2·7 = 14
+samples per window. Drag the count across that line — below it the fast wave
+folds down to a slower impostor, and at exactly 10 samples, 7 folds to
+10 − 7 = 3: its samples become *identical* to the slow wave's.
+```
+samples = input::int(min: 4, max: 64, step: 1, default: 10)
+fast_sampled = signal::sample(fast, samples)
+slow_sampled = signal::sample(slow, samples)
+fast_full    = signal::sample(fast, 64)
+twin_error   = vec::mse(fast_sampled, slow_sampled)
+full_error   = vec::mse(fast_full, signal::sample(slow, 64))
+
+```md
+Undersampled at ${samples} points: mse(fast, slow) = **${twin_error}** — when
+it reads 0, the two waves are indistinguishable. Oversampled at 64 points:
+mse = **${full_error}** — obviously different signals.
 ```
 
 ```md
-oversampled (64 > 14 pts): mse(fast, slow) = **${vec::mse(signal::sample(high, 64), signal::sample(low, 64))}**
+**Watch the disguise.** The fast wave's samples, the slow wave's samples —
+and then the fast wave again with 64 snapshots, all seven wiggles restored.
 ```
-
-```md
-Sample too slowly and a 7-cycle wave masquerades as a 3-cycle one (7 folds to 10-7 = 3).
-```
-
-// Undersampled (at 10): the fast 7-cycle wave and the slow 3-cycle wave land on the SAME points — twins.
-plot::line(signal::sample(high, samples));
-plot::line(signal::sample(low, samples));
-// Oversampled at 64: now the fast wave shows all 7 wiggles and is obviously a different signal.
-plot::line(signal::sample(high, 64))
+plot::line(fast_sampled)
+plot::line(slow_sampled)
+plot::line(fast_full)

--- a/examples/pi.noise
+++ b/examples/pi.noise
@@ -12,11 +12,11 @@ Throw darts at random at a 2-by-2 square with the unit circle drawn inside.
 The circle covers π/4 of the square's area, so the fraction of darts that land
 in it, times 4, is π. No formula for the circle — just a tally of hits.
 ```
-X ~ rand::unif(-1, 1);
-Y ~ rand::unif(-1, 1);
+X ~ rand::unif(-1, 1)
+Y ~ rand::unif(-1, 1)
 
 // 1e-4 asks for precision, not a draw count: the engine throws as many darts as that takes.
-pi = 4 * P(X^2 + Y^2 < 1, 1e-4);
+pi = 4 * P(X^2 + Y^2 < 1, 1e-4)
 ```latex
 \pi \approx 4 \cdot P\!\left(X^2 + Y^2 < 1\right) = ${pi}
 ```

--- a/examples/pi.noise
+++ b/examples/pi.noise
@@ -7,14 +7,15 @@ abstract: >
   turning a question about geometry into a number by sampling.
 tags: [basics, monte carlo, precision]
 ---
-// Throw darts at a 2-by-2 square: each dart is a random (X, Y) point.
+```md
+Throw darts at random at a 2-by-2 square with the unit circle drawn inside.
+The circle covers π/4 of the square's area, so the fraction of darts that land
+in it, times 4, is π. No formula for the circle — just a tally of hits.
+```
 X ~ rand::unif(-1, 1);
 Y ~ rand::unif(-1, 1);
 
-// A dart lands inside the unit circle when X² + Y² < 1, and that circle covers
-// exactly π/4 of the square — so the hit fraction, times 4, IS π.
-// The second argument asks for DIGITS, not draws: keep sampling until the answer
-// is good to 1 part in 10,000. The engine works out how many darts that takes.
+// 1e-4 asks for precision, not a draw count: the engine throws as many darts as that takes.
 pi = 4 * P(X^2 + Y^2 < 1, 1e-4);
 ```latex
 \pi \approx 4 \cdot P\!\left(X^2 + Y^2 < 1\right) = ${pi}

--- a/examples/prisoners.noise
+++ b/examples/prisoners.noise
@@ -8,27 +8,42 @@ abstract: >
 tags: [classic, permutations]
 ---
 
-use vec;
+use vec
 
-// The boxes are a uniform random permutation: box k contains the number boxes[k].
-n     = 100;
-opens = 50;
-boxes ~ rand::permutation(n);
-
-// The escape succeeds exactly when the shuffle has no cycle longer than 50 — that's the whole secret.
-all_win = true;
-for prisoner in 0..n {
-  box   = prisoner;       // start by opening your own numbered box
-  found = false;
-  for hop in 0..opens {
-    box   = boxes[box];                  // open the box the last number pointed to
-    found = found || (box == prisoner);  // did we just uncover our own number?
-  };
-  all_win = all_win && found;
-};
-
-// Heavier than most examples: each sample chases pointers through 100 boxes. Asking for half-a-
-// percent relative precision keeps it snappy — the engine draws only what that costs.
 ```md
-P(all 100 prisoners go free) = **${P(all_win, 2e-3) * 100}%** (analytic ≈ 31.2%)
+**The shuffle.** Box k holds number `boxes[k]` — a uniform random permutation
+of all one hundred numbers.
+```
+n     = 100
+opens = 50
+boxes ~ rand::permutation(n)
+
+```md
+**The chain strategy.** Each prisoner opens their own numbered box first, then
+follows wherever the number inside points. The escape succeeds exactly when
+the shuffle has no cycle longer than 50 — that is the whole secret.
+```
+all_win = true
+for prisoner in 0..n {
+  box   = prisoner
+  found = false
+  for hop in 0..opens {
+    box   = boxes[box]
+    found = found || (box == prisoner)
+  }
+  all_win = all_win && found
+}
+
+// Heavier than most examples: each sample chases pointers through 100 boxes. Half-a-percent
+// relative precision keeps it snappy — the engine draws only what that costs.
+p_free = P(all_win, 2e-3)
+
+```md
+**The verdict.** All hundred walk free **${p_free * 100}%** of the time —
+absurdly far above the 0.5^100 of random guessing. The law behind it: the
+strategy fails only when the shuffle contains a cycle longer than half the
+boxes:
+```
+```latex
+P(\text{all free}) = 1 - \sum_{k=51}^{100} \frac{1}{k} \approx ${p_free}
 ```

--- a/examples/qjl_scalar.noise
+++ b/examples/qjl_scalar.noise
@@ -7,14 +7,23 @@ abstract: >
   trick is the seed of the TurboQuant sketch.
 tags: [research, continuous]
 ---
-use math;   // sqrt, pi
+use math   // sqrt, pi
 
-s ~ rand::normal(0, 1);
-estimate = sqrt(pi / 2) * s * sign(s);          // = sqrt(pi/2) * |s|
+```md
+**Keep one bit.** Draw a standard normal, throw away everything but its sign,
+then rescale by √(π/2). The magnitude looks gone — but on average it isn't:
+```
+s ~ rand::normal(0, 1)
+estimate = sqrt(pi / 2) * s * sign(s)
+mean_estimate = E(estimate)
+spread        = Var(estimate)
 ```latex
-E[\text{QJL 1-D estimate}] = ${E(estimate)} \qquad (\text{unbiased target} = 1.0)
-\mathrm{Var}[\text{estimate}] = ${Var(estimate)}
+E[\text{QJL 1-D estimate}] = ${mean_estimate} \qquad (\text{unbiased target} = 1.0),
+\qquad \mathrm{Var} = ${spread}
 ```
 
-// A folded normal — skewed and spread — yet its average is pinned to 1. One bit throws away a lot, but not the mean.
+```md
+**The price of the bit.** A folded normal — skewed and spread — yet its
+average is pinned to 1. One bit throws away a lot, but not the mean.
+```
 plot::histogram(estimate)

--- a/examples/rare_event.noise
+++ b/examples/rare_event.noise
@@ -9,16 +9,22 @@ abstract: >
 tags: [risk, precision, tails]
 ---
 
-// A year of market returns, roughly bell-shaped: most years are ordinary.
-returns ~ rand::normal(0, 1);
+```md
+**The catastrophe.** A year of market returns, roughly bell-shaped — and the
+crash is a 3.7-sigma day in the far left tail, about once in ten thousand
+years.
+```
+returns ~ rand::normal(0, 1)
+crash = returns < -3.7
 
-// The catastrophe: a 3.7-sigma crash. It happens about once in ten thousand years.
-crash = returns < -3.7;
+```md
+**Ask for precision, not draws.** A fixed budget spends almost everything on
+ordinary years. Asking for 10% *relative* error instead keeps the engine
+drawing until the rare corner of the distribution has been seen often enough
+to pin down.
+```
+p_crash = P(crash, 0.1)
 
-// Ask for the answer to 10% RELATIVE error — not for a sample count. A fixed budget
-// spends almost all of it on ordinary years; a relative target keeps drawing until
-// the rare corner of the distribution has been seen often enough to pin down.
-p_crash = P(crash, 0.1);
 ```md
 P(crash) = **${p_crash}** — about one year in ${math::round(1 / p_crash, 0)}.
 ```

--- a/examples/reliability.noise
+++ b/examples/reliability.noise
@@ -7,19 +7,26 @@ abstract: >
   How many spares does it take to buy each extra nine of reliability?
 tags: [engineering, collections]
 ---
-part   = rand::bernoulli(0.9);
 
-// Each parallel spare multiplies the odds of a TOTAL failure by another 0.1, so reliability
-// marches 0.9 → 0.99 → 0.999: one extra nine bought per part.
-n      = input::int(min: 1, max: 6, step: 1, default: 3);
+```md
+**Parallel spares.** One flaky 90% part, wired n-way parallel: the system is
+up as long as *any* copy survives. Each extra spare multiplies the odds of a
+total failure by another 0.1 — one more nine of reliability per part.
+```
+part = rand::bernoulli(0.9)
+n    = input::int(min: 1, max: 6, step: 1, default: 3)
 
-parts  ~[n] part;
-up     = vec::any(parts);
+parts ~[n] part
+up    = vec::any(parts)
+p_up  = P(up)
 ```latex
-P(\text{system up}) = ${P(up) * 100}\% \qquad (\text{${n}-way parallel})
+P(\text{system up}) = ${p_up * 100}\% \qquad (\text{${n}-way parallel})
 ```
 
-// The nines pile up geometrically — reliability rockets toward certainty, then flattens
-// as each additional spare buys a smaller and smaller slice.
-reliab_by_count = [for k in 1..7 { 1 - 0.1 ^ k }];
-plot::line(reliab_by_count)
+```md
+**The nines pile up.** Simulate every spare count from 1 to 6: reliability
+rockets toward certainty, then flattens as each extra part buys a smaller
+slice.
+```
+reliability_by_count = [for k in 1..7 { spares ~[k] part; P(vec::any(spares)) }]
+plot::line(reliability_by_count)

--- a/examples/secretary.noise
+++ b/examples/secretary.noise
@@ -8,42 +8,42 @@ abstract: >
 tags: [classic, optimal stopping]
 ---
 
-use vec;
+use vec
 
 ```md
 **The pool.** Twenty applicants walk in, one at a time, each with a hidden
 quality score. Nothing short of hiring the *best of all of them* counts.
 ```
-total_candidates = 20;
-quality ~[total_candidates] rand::unif(0, 1);
-best_candidate = max(quality);
+total_candidates = 20
+quality ~[total_candidates] rand::unif(0, 1)
+best_candidate = max(quality)
 
 ```md
 **The cutoff.** The whole strategy hinges on one number: how many applicants
 to sacrifice as pure observation before you're allowed to hire. Try dragging
 **r**.
 ```
-r = input::int(min: 1, max: 19, step: 1, default: 7);
+r = input::int(min: 1, max: 19, step: 1, default: 7)
 
 ```md
 **Observation phase.** Interview and reject the first r applicants no matter
 what — the best of them sets the *bar*.
 ```
-bar = max(quality[0..r]);
+bar = max(quality[0..r])
 
 ```md
 **Hiring phase.** The first applicant to clear the bar gets the job; if nobody
 ever does, you're stuck with the last one.
 ```
-hired_candidate = quality[total_candidates - 1];
-stopped = false;
+hired_candidate = quality[total_candidates - 1]
+stopped = false
 for i in r..total_candidates {
-  take            = quality[i] > bar && !stopped;
-  hired_candidate = if take { quality[i] } else { hired_candidate };
-  stopped         = stopped || take;
-};
-win   = hired_candidate == best_candidate;
-p_win = P(win);
+  take            = quality[i] > bar && !stopped
+  hired_candidate = if take { quality[i] } else { hired_candidate }
+  stopped         = stopped || take
+}
+win   = hired_candidate == best_candidate
+p_win = P(win)
 
 ```md
 **The verdict.** Rejecting the first ${r} of ${total_candidates} lands the very best

--- a/examples/secretary.noise
+++ b/examples/secretary.noise
@@ -10,28 +10,47 @@ tags: [classic, optimal stopping]
 
 use vec;
 
-// Each candidate's quality is a fresh uniform; since they're iid, the arrival order is already
-// random. "Best" is the global maximum, and we win iff our rule hires exactly that candidate.
-n = 20;
-
-// Slide the cutoff: the win rate peaks when you look at about n/e ~ 7 of the 20, then falls away.
-r = input::int(min: 1, max: 19, step: 1, default: 7);   // observe-only phase, then take the next record-breaker
-
-trial(n, r) = {
-  c    ~[n] rand::unif(0, 1);
-  best = max(c);
-  bar  = c[0];                            // best quality seen during the observe-only phase
-  for i in 1..r { bar = if c[i] > bar { c[i] } else { bar } };
-  pick    = c[n - 1];                     // if nobody beats the bar, you're stuck with the last
-  stopped = false;
-  for i in r..n {
-    take    = c[i] > bar && !stopped;     // hire the first candidate above the bar
-    pick    = if take { c[i] } else { pick };
-    stopped = stopped || take;
-  };
-  pick == best                            // did we land the very best of all n?
-};
+```md
+**The pool.** Twenty applicants walk in, one at a time, each with a hidden
+quality score. Nothing short of hiring the *best of all of them* counts.
+```
+total_candidates = 20;
+quality ~[total_candidates] rand::unif(0, 1);
+best_candidate = max(quality);
 
 ```md
-P(hire the best of ${n} after rejecting the first ${r}) = **${P(trial(n, r)) * 100}%** (~ 1/e ≈ 37%)
+**The cutoff.** The whole strategy hinges on one number: how many applicants
+to sacrifice as pure observation before you're allowed to hire. Try dragging
+**r**.
+```
+r = input::int(min: 1, max: 19, step: 1, default: 7);
+
+```md
+**Observation phase.** Interview and reject the first r applicants no matter
+what — the best of them sets the *bar*.
+```
+bar = max(quality[0..r]);
+
+```md
+**Hiring phase.** The first applicant to clear the bar gets the job; if nobody
+ever does, you're stuck with the last one.
+```
+hired_candidate = quality[total_candidates - 1];
+stopped = false;
+for i in r..total_candidates {
+  take            = quality[i] > bar && !stopped;
+  hired_candidate = if take { quality[i] } else { hired_candidate };
+  stopped         = stopped || take;
+};
+win   = hired_candidate == best_candidate;
+p_win = P(win);
+
+```md
+**The verdict.** Rejecting the first ${r} of ${total_candidates} lands the very best
+applicant **${p_win * 100}%** of the time. The peak is the famous 1/e law —
+observe a 1/e slice of the pool, and you land the best about 1/e of the time:
+```
+```latex
+P(\text{win}) = \frac{r}{n}\sum_{k=r}^{n-1}\frac{1}{k} \approx ${p_win},
+\qquad \text{maximized at } r = \frac{n}{e} \approx ${math::round(total_candidates / math::e, 0)}
 ```

--- a/examples/shor_period.noise
+++ b/examples/shor_period.noise
@@ -9,61 +9,71 @@ abstract: >
 tags: [quantum, classic]
 ---
 
-use math;
-use vec;
+use math
+use vec
 
-// A 2^n simulation: gorgeous for small N, never efficient — what's faithful is the PHYSICS, the
-// amplitudes and their interference. (Efficient Shor needs a real quantum computer.)
+```md
+**A toy quantum computer.** This is a full 2^n simulation — gorgeous for
+small N, never efficient. What's faithful is the *physics*: the amplitudes
+and their interference. (Efficient Shor needs the real machine.) Two pieces
+of plumbing: a one-hot row to encode a value, and the counting register — the
+smallest power of two that fits N.
+```
+onehot(v, width) = [for w in 0..width { if v == w { 1 } else { 0 } }]
+reg_size(N) = { Q = 1; for i in 0..16 { if Q < N { Q = Q * 2 } }; Q }
 
-// one-hot encode a value v as a length-`width` row: 1 in column v, 0 elsewhere.
-onehot(v, width) = [for w in 0..width { if v == w { 1 } else { 0 } }];
+```md
+**The quantum subroutine.** Superpose every input x, apply the oracle
+a^x mod N, and inverse-QFT the state. Amplitudes from the same residue
+*reinforce* while the rest *cancel* — the one place ℂ does real work — and
+the readout probabilities pile into a comb of exactly r equally-spaced
+spikes. The period is just the number of spikes.
+```
+interference(a, N, Q) = {
+  Psi = [for x in 0..Q { onehot(math::modpow(a, x, N), N) }] / Q ^ 0.5
+  QFT = math::exp(math::i * (-2 * math::pi / Q) * vec::outer(0..Q, 0..Q)) / Q ^ 0.5;
+  [for p in QFT @ Psi { vec::normsq(p) }]
+}
+period(a, N, Q) = vec::count(interference(a, N, Q) > 0.0001)
 
-// the counting register: the smallest power of two >= N.
-reg_size(N) = { Q = 1; for i in 0..16 { if Q < N { Q = Q * 2 } }; Q };
-
-// --- the QUANTUM subroutine: the period r of a^x mod N, read off the interference comb ---
-// Build the superposition over all inputs, inverse-QFT it, and the readout probabilities form a comb
-// of exactly r equally-spaced spikes — so the period is just the number of spikes.
-period(a, N, Q) = {
-  ks  = 0..Q;
-  fx  = [for x in 0..Q { math::modpow(a, x, N) }];          // the oracle on every input
-  Psi = [for x in 0..Q { onehot(fx[x], N) }] / Q ^ 0.5;     // entangle + normalize the state
-  // Same-residue amplitudes REINFORCE, the rest CANCEL — the one place ℂ is doing real work.
-  QFT = math::exp(math::i * (-2 * math::pi / Q) * vec::outer(ks, ks)) / Q ^ 0.5;
-  vec::count([for p in QFT @ Psi { vec::normsq(p) > 0.0001 }])   // r = number of spikes in the comb
-};
-
-// --- Shor's algorithm: factor N ---
-// Try a handful of bases (a real machine picks them at random). If a already shares a factor, gcd
-// hands one over; otherwise use the quantum period r and read factors from gcd(a^(r/2) +- 1, N).
+```md
+**The classical wrapper.** Try a handful of bases (a real machine picks them
+at random). A base already sharing a factor hands it over via gcd; otherwise
+the quantum period r — when even — reads out factors from gcd(a^(r/2) ± 1, N).
+```
 shor(N) = {
-  Q = reg_size(N);
-  p = 1; q = N;                                       // p == 1 means "no nontrivial factor yet"
+  Q = reg_size(N)
+  p = 1; q = N
   for a in 2..14 { if a < N { if p == 1 {
     if math::gcd(a, N) > 1 { p = math::gcd(a, N); q = N / p }
     else {
-      r = period(a, N, Q);                            // the quantum step
-      if r % 2 == 0 {                                 // need an even period
-        s = math::modpow(a, r / 2, N);
-        g = math::gcd(s - 1, N);
-        if g > 1 { if g < N { p = g; q = N / g } }    // a nontrivial factor — done
+      r = period(a, N, Q)
+      if r % 2 == 0 {
+        s = math::modpow(a, r / 2, N)
+        g = math::gcd(s - 1, N)
+        if g > 1 { if g < N { p = g; q = N / g } }
       }
     }
-  } } };
+  } } };   // `;` needed: a line starting with `[` would otherwise index the loop above
   [p, q]
-};
-
-// Composites split into their two primes; a prime returns itself — nothing to break, which is
-// exactly the wall RSA hides behind.
-n_to_factor = input::int(min: 15, max: 35, step: 2, default: 15);
-
-// The interference comb for 2^x mod N: Q readout slots where the amplitudes pile into evenly-spaced
-// spikes, one per period step. Counting the spikes IS the quantum measurement the whole trick rests on.
-Q    = reg_size(n_to_factor);
-Psi  = [for x in 0..Q { onehot(math::modpow(2, x, n_to_factor), n_to_factor) }] / Q ^ 0.5;
-comb = [for y in (math::exp(math::i * (-2 * math::pi / Q) * vec::outer(0..Q, 0..Q)) / Q ^ 0.5) @ Psi { vec::normsq(y) }];
-plot::line(comb);
+}
 
 ```md
-Shor factors **${n_to_factor}** into **${shor(n_to_factor)}**.
+**Pick a number.** Composites split into their two primes; a prime returns
+itself — nothing to break, which is exactly the wall RSA hides behind.
+```
+n_to_factor = input::int(min: 15, max: 35, step: 2, default: 15)
+
+```md
+**The comb.** The readout probabilities for base 2: amplitudes piled into
+evenly-spaced spikes, one per period step. Counting them *is* the quantum
+measurement the whole trick rests on.
+```
+Q = reg_size(n_to_factor)
+readout = interference(2, n_to_factor, Q)
+plot::line(readout)
+
+factors = shor(n_to_factor)
+```md
+**The verdict.** Shor factors **${n_to_factor}** into **${factors}**.
 ```

--- a/examples/st_petersburg.noise
+++ b/examples/st_petersburg.noise
@@ -8,41 +8,51 @@ abstract: >
 tags: [paradox, expectation]
 ---
 
-// The trick behind the infinity: each round contributes exactly $1 to the expectation
-// (a 2^k prize paid with probability 1/2^k), so capping at N rounds gives E ≈ N — forever.
+```md
+**The game, capped.** Flip until the first head; heads on flip k pays 2^k.
+The trick behind the infinity: each round contributes exactly $1 to the
+expectation — a 2^k prize at 1-in-2^k odds — so a game allowed to run N
+rounds has a fair price of about $N.
+```
 play(rounds) = {
-  flips  ~[rounds] rand::bernoulli(0.5);
-  payout = 0;
-  live   = true;
+  flips  ~[rounds] rand::bernoulli(0.5)
+  payout = 0
+  live   = true
   for k in 0..rounds {
-    first  = flips[k] && live;            // the first head lands here — it ends the game
-    payout = if first { 2 ^ (k + 1) } else { payout };
-    live   = live && !flips[k];
-  };
+    first  = flips[k] && live
+    payout = if first { 2 ^ (k + 1) } else { payout }
+    live   = live && !flips[k]
+  }
   payout
-};
+}
 
 ```md
-Expected payout keeps growing as you allow more rounds (E ~ number of rounds):
+**The ladder.** Raise the cap and watch the fair price track it, a dollar per
+round, refusing to converge:
 ```
+e_short  = E(play(4))
+e_medium = E(play(8))
+e_long   = E(play(12))
 ```latex
-E[\text{payout up to 4 rounds}] = ${E(play(4))} \quad (\approx 4)
-E[\text{payout up to 8 rounds}] = ${E(play(8))} \quad (\approx 8)
-E[\text{payout up to 12 rounds}] = ${E(play(12))} \quad (\approx 12)
+E[\text{payout} \mid 4 \text{ rounds}] = ${e_short}, \quad
+E[\text{payout} \mid 8 \text{ rounds}] = ${e_medium}, \quad
+E[\text{payout} \mid 12 \text{ rounds}] = ${e_long} \qquad (E \approx N)
 ```
-
-// Drag the cap on rounds: the expected payout just keeps climbing (~$1 per round), never settling
-// on a finite fair price — the "infinite" expectation is real, watch it refuse to converge.
-rounds = input::int(min: 1, max: 20, step: 1, default: 8);
-
-```latex
-E[\text{payout up to } ${rounds} \text{ rounds}] = ${E(play(rounds))} \quad (\approx ${rounds})
-```
-
-// The mean hides in rare jackpots — the histogram shows that long, heavy tail.
-plot::histogram(play(rounds));
 
 ```md
-Each extra round adds about $1 of expected value forever, so no finite price is fair.
-(The mean lives in ever-rarer jackpots, so longer games need exponentially more samples.)
+**Your turn.** Drag the cap — the expected payout climbs about $1 per round,
+forever. The "infinite" expectation is real.
 ```
+rounds   = input::int(min: 1, max: 20, step: 1, default: 8)
+e_capped = E(play(rounds))
+```latex
+E[\text{payout} \mid ${rounds} \text{ rounds}] = ${e_capped} \qquad (\approx ${rounds})
+```
+
+```md
+**Where the mean hides.** Almost every game pays a pittance; the expectation
+lives in ever-rarer jackpots out in the long tail — which is exactly why no
+sane person pays the "fair" price. (It's also why longer games need
+exponentially more samples to pin down.)
+```
+plot::histogram(play(rounds))

--- a/examples/turboquant.noise
+++ b/examples/turboquant.noise
@@ -7,78 +7,105 @@ abstract: >
   reproduces that hidden bias from a recent paper, and the one-bit sketch that fixes it.
 tags: [research, capstone]
 ---
-use math;     // pi, sqrt, sign
-use vec;      // normalize, ones, iota, quantize, normsq, norm, transpose
+use math     // pi, sqrt, sign
+use vec      // normalize, ones, iota, quantize, normsq, norm, transpose
 
 // Each sample rotates and quantizes a 20-dimensional vector — a lot of work per draw. Ask for
 // the ~2 significant digits the paper comparison needs, and let every E() size itself.
-engine::set_precision(5e-3);
+engine::set_precision(5e-3)
 
-// A fixed unit vector x and unit query y (any fixed pair works); we estimate <y, x>.
-d = 20;
-x = normalize(ones(d));
-y = normalize(iota(d));
-true_ip = y @ x;          // `@` is the matrix product (here a vector dot)
+```md
+**The target.** A fixed unit vector x, a fixed unit query y, and the number
+we must preserve through compression: their inner product.
+```
+d = 20
+x = normalize(ones(d))
+y = normalize(iota(d))
+true_ip = y @ x
 
-// Optimal scalar (Lloyd-Max) codebooks for the rotated coordinates, which are ~Normal(0, 1/d). These
-// are the standard unit-Gaussian quantization levels, rescaled by 1/sqrt(d). b bits -> 2^b levels.
-s  = 1 / sqrt(d);
-L1 = [-0.7979, 0.7979] * s;                                                              // b=1: 2 levels
-L2 = [-1.5104, -0.4528, 0.4528, 1.5104] * s;                                             // b=2: 4 levels
-L3 = [-2.1520, -1.3439, -0.7560, -0.2451, 0.2451, 0.7560, 1.3439, 2.1520] * s;           // b=3: 8 levels
+```md
+**The codebooks.** After a random rotation each coordinate is ~Normal(0, 1/d),
+so the optimal (Lloyd–Max) quantization levels are the standard unit-Gaussian
+ones, rescaled by 1/√d. b bits buy 2^b levels.
+```
+s  = 1 / sqrt(d)
+L1 = [-0.7979, 0.7979] * s
+L2 = [-1.5104, -0.4528, 0.4528, 1.5104] * s
+L3 = [-2.1520, -1.3439, -0.7560, -0.2451, 0.2451, 0.7560, 1.3439, 2.1520] * s
 L4 = [-2.7326, -2.0690, -1.6181, -1.2562, -0.9423, -0.6568, -0.3881, -0.1284,
-       0.1284,  0.3881,  0.6568,  0.9423,  1.2562,  1.6181,  2.0690,  2.7326] * s;        // b=4: 16 levels
+       0.1284,  0.3881,  0.6568,  0.9423,  1.2562,  1.6181,  2.0690,  2.7326] * s
 
-// === Algorithm 1: the MSE-optimal quantizer. Rotate, snap each coordinate to its nearest level,
-//     rotate back. Distortion D_mse = E||x - xhat||^2 should match the paper's table.
-Pi  ~ rand::rotation(d);                 // fresh random rotation per Monte Carlo sample (a draw)
-rot = Pi @ x;                      // rotated coordinates, each ~ Normal(0, 1/d)  (mat @ vec)
-PiT = transpose(Pi);          // rotate the reconstruction back
-mse1 = PiT @ quantize(rot, L1);   // 1-bit MSE reconstruction
-mse2 = PiT @ quantize(rot, L2);
-mse3 = PiT @ quantize(rot, L3);
-mse4 = PiT @ quantize(rot, L4);
-
+```md
+**Algorithm 1 — the obvious quantizer.** Rotate, snap every coordinate to its
+nearest level, rotate back. Reconstruction distortion lands right on the
+paper's table:
+```
+Pi  ~ rand::rotation(d)
+rot = Pi @ x
+PiT = transpose(Pi)
+mse1 = PiT @ quantize(rot, L1)
+mse2 = PiT @ quantize(rot, L2)
+mse3 = PiT @ quantize(rot, L3)
+mse4 = PiT @ quantize(rot, L4)
+d_mse1 = E(normsq(x - mse1))
+d_mse2 = E(normsq(x - mse2))
+d_mse3 = E(normsq(x - mse3))
+d_mse4 = E(normsq(x - mse4))
 ```latex
-D_{\text{mse}},\ b = 1 = ${E(normsq(x - mse1))} \qquad(\text{paper } 0.36)
-D_{\text{mse}},\ b = 2 = ${E(normsq(x - mse2))} \qquad(\text{paper } 0.117)
-D_{\text{mse}},\ b = 3 = ${E(normsq(x - mse3))} \qquad(\text{paper } 0.03)
-D_{\text{mse}},\ b = 4 = ${E(normsq(x - mse4))} \qquad(\text{paper } 0.009)
+D_{\text{mse}},\ b = 1 = ${d_mse1} \qquad(\text{paper } 0.36)
+D_{\text{mse}},\ b = 2 = ${d_mse2} \qquad(\text{paper } 0.117)
+D_{\text{mse}},\ b = 3 = ${d_mse3} \qquad(\text{paper } 0.03)
+D_{\text{mse}},\ b = 4 = ${d_mse4} \qquad(\text{paper } 0.009)
 ```
 
-// === The catch: that 1-bit MSE quantizer is BIASED for inner products by exactly 2/pi.
+```md
+**The catch.** Great at reconstruction — yet for *inner products* the 1-bit
+MSE quantizer is biased by exactly 2/π:
+```
+bias_ratio = E(y @ mse1) / true_ip
 ```latex
-\text{MSE } b = 1: \quad \frac{E[\text{est}]}{\text{true}} = ${E(y @ mse1) / true_ip} \qquad(\text{biased: } \tfrac{2}{\pi} = ${2 / pi})
+\text{MSE } b = 1: \quad \frac{E[\text{est}]}{\text{true}} = ${bias_ratio}
+\qquad(\text{biased: } \tfrac{2}{\pi} = ${round(2 / pi, 4)})
 ```
 
-// === Algorithm 2: TurboQuant_prod. The MSE reconstruction `m` (at b-1 bits) plus a 1-bit QJL sketch
-//     of its residual r = x - m, using an independent Gaussian projection S, rescaled by ||r||.
-//     `tq_ip` returns the resulting estimate of <y, x>; it is provably unbiased (Theorem 2).
+```md
+**Algorithm 2 — TurboQuant.** Spend b−1 bits on the MSE stage, then sketch its
+*residual* with the one-bit QJL trick: an independent Gaussian projection S,
+signs only, rescaled by ‖r‖ and √(π/2). Provably unbiased (Theorem 2); each
+stage draws its own fresh rotation / projection per sample. (b = 1 has a
+0-bit MSE stage — a codebook of {0} — so it's plain QJL.)
+```
 tq_ip(x, y, m, S, dd) =
     y @ m
   + sqrt(pi / 2) / dd * norm(x - m)
-    * (y @ (transpose(S) @ sign(S @ (x - m))));
-    
-// Target b spends (b-1) bits on the MSE stage and 1 bit on the QJL residual. Each stage draws its
-// own fresh rotation / projection per sample. (b=1 has a 0-bit MSE stage -> codebook {0} -> plain QJL.)
-S1 ~[d, d] rand::normal(0, 1);
-S2 ~[d, d] rand::normal(0, 1);  R2 ~ rand::rotation(d);
-S3 ~[d, d] rand::normal(0, 1);  R3 ~ rand::rotation(d);
-S4 ~[d, d] rand::normal(0, 1);  R4 ~ rand::rotation(d);
-m1 = zeros(d);                                                             // 0-bit MSE -> just QJL
-m2 = transpose(R2) @ quantize(R2 @ x, L1);    // 1-bit MSE + QJL
-m3 = transpose(R3) @ quantize(R3 @ x, L2);    // 2-bit MSE + QJL
-m4 = transpose(R4) @ quantize(R4 @ x, L3);    // 3-bit MSE + QJL
-prod1 = tq_ip(x, y, m1, S1, d);
-prod2 = tq_ip(x, y, m2, S2, d);
-prod3 = tq_ip(x, y, m3, S3, d);
-prod4 = tq_ip(x, y, m4, S4, d);
+    * (y @ (transpose(S) @ sign(S @ (x - m))))
 
-// The fix lands on 1 — unbiased — and its squared error shrinks like 1/d as bits are added, a fraction of the biased quantizer's.
+S1 ~[d, d] rand::normal(0, 1)
+S2 ~[d, d] rand::normal(0, 1);  R2 ~ rand::rotation(d)
+S3 ~[d, d] rand::normal(0, 1);  R3 ~ rand::rotation(d)
+S4 ~[d, d] rand::normal(0, 1);  R4 ~ rand::rotation(d)
+m1 = zeros(d)
+m2 = transpose(R2) @ quantize(R2 @ x, L1)
+m3 = transpose(R3) @ quantize(R3 @ x, L2)
+m4 = transpose(R4) @ quantize(R4 @ x, L3)
+prod1 = tq_ip(x, y, m1, S1, d)
+prod2 = tq_ip(x, y, m2, S2, d)
+prod3 = tq_ip(x, y, m3, S3, d)
+prod4 = tq_ip(x, y, m4, S4, d)
+
+```md
+**The verdict.** The fix lands on 1 — unbiased — and its squared error
+shrinks like 1/d as bits are added, a fraction of the biased quantizer's:
+```
+unbias_ratio = E(prod2) / true_ip
+d_prod1 = E((prod1 - true_ip) ^ 2)
+d_prod2 = E((prod2 - true_ip) ^ 2)
+d_prod3 = E((prod3 - true_ip) ^ 2)
+d_prod4 = E((prod4 - true_ip) ^ 2)
 ```latex
-\text{prod } b = 2: \quad \frac{E[\text{est}]}{\text{true}} = ${E(prod2) / true_ip} \qquad(\text{unbiased} \approx 1)
-D_{\text{prod}},\ b = 1 = ${E((prod1 - true_ip) ^ 2)} \qquad(\text{plain QJL};\ \le \text{ bound } \tfrac{\pi}{2d} = ${pi / 2 / d})
-D_{\text{prod}},\ b = 2 = ${E((prod2 - true_ip) ^ 2)} \qquad(\text{paper } \tfrac{0.56}{d} = ${0.56 / d})
-D_{\text{prod}},\ b = 3 = ${E((prod3 - true_ip) ^ 2)} \qquad(\text{paper } \tfrac{0.18}{d} = ${0.18 / d})
-D_{\text{prod}},\ b = 4 = ${E((prod4 - true_ip) ^ 2)} \qquad(\text{paper } \tfrac{0.047}{d} = ${0.047 / d})
+\text{prod } b = 2: \quad \frac{E[\text{est}]}{\text{true}} = ${unbias_ratio} \qquad(\text{unbiased} \approx 1)
+D_{\text{prod}},\ b = 1 = ${d_prod1} \qquad(\text{plain QJL};\ \le \text{ bound } \tfrac{\pi}{2d} = ${round(pi / 2 / d, 4)})
+D_{\text{prod}},\ b = 2 = ${d_prod2} \qquad(\text{paper } \tfrac{0.56}{d} = ${0.56 / d})
+D_{\text{prod}},\ b = 3 = ${d_prod3} \qquad(\text{paper } \tfrac{0.18}{d} = ${0.18 / d})
+D_{\text{prod}},\ b = 4 = ${d_prod4} \qquad(\text{paper } \tfrac{0.047}{d} = ${0.047 / d})
 ```


### PR DESCRIPTION
This commit introduces a new feature for deterministic array slicing, allowing users to select elements from an array using a deterministic array of indices. The documentation in `LANG.md` has been updated to reflect this new functionality, explaining how to use index arrays for slicing and the rules governing their usage. Additionally, the `SKILL.md` file has been revised to clarify the output of Noise programs as documents, and various examples have been updated for improved clarity and interactivity. Tests have also been added to ensure the correctness of the new slicing behavior.